### PR TITLE
Rename windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ Required libraries:
 4. After selecting the gaze file, the program will ask you to select the corresponding fixation file.
 5. A prompt will then appear asking you to select the location where you would like all the output files to be saved.
 6. The program will then ask you to input the name of the folder/participant.
-7. Once the program finishes analyzing and outputting the initial data, it will ask whether or not you would like to generate snapshots of the gaze/fixation data.
-    * If you select yes then the program will give you four different snapshot options:
-        - Continuous Snapshot: This option generates gaze data in a series of fixed, nonoverlapping windows.
-        - Cumulative Snapshot: This option generates gaze data in a series of expanding windows that increases with every interval.
-        - Overlapping Snapshot: This option generates gaze data in a series of fixed and overlapping windows.
-        - Event Analytics: This option generates a baseline file based on the first two minutes of the gaze data, and then compares it to the rest of the file. If the data exceeds the baseline value, it will be counted as an event, and the program will continue to search for the next event within a specified time period. If no event is found, the program will close at a specific period. If another event is found, the session window will continue searching.
+7. Once the program finishes analyzing and outputting the initial data, it will ask whether or not you would like to generate schedules pr even-based windows of the gaze/fixation data.
+    * If you select yes then the program will give you four different window options:
+        - Gaze Digests: This option generates gaze data in a series of fixed, nonoverlapping windows.
+        - Cumulative Gaze: This option generates gaze data in a series of expanding windows that increases with every interval.
+        - Gaze Snapshots: This option generates gaze data in a series of fixed and overlapping windows.
+        - Gaze Events: This option generates a baseline file based on the first two minutes of the gaze data, and then compares it to the rest of the file. If the data exceeds the baseline value, it will be counted as an event, and the program will continue to search for the next event within a specified time period. If no event is found, the program will close at a specific period. If another event is found, the session window will continue searching.
 8. Depending on the option you choose, the program will ask for different input. For the first three options, the program will ask you to select the window size and/or overlapping amount (both in terms of time in seconds).
 9. If you choose the last option, Event Analytics, the program will ask you which gaze or fixation file you would like to analyze. The program will create a baseline file based on the first two minutes and then ask you to pick a baseline value and a value from the file you inputted to compare 
     to each other, as well as a maximum duration of an event.

--- a/README.txt
+++ b/README.txt
@@ -21,15 +21,15 @@ Setup
 		1) Clone the repository to your local machine using git or your preferred version control system.
 		2) Ensure that you have all the required libraries installed and run the program
 		3) Upon launching the program, the Data Analysis Page will initialize. Users can navigate through the various tabs located in the top left corner to access the desired analysis features. The program will prompt the user to input the gaze and fixation files, specify the desired location 
-		   for the output files, and provide the participant’s name for the output folder naming convention.
-		4) The program will then display a new screen where the user will have the option to select specific windows for the output. If the user chooses not to select a window, they can simply select the ”Exit” option and submit, and the program will automatically terminate. However, if the user 
+		   for the output files, and provide the participantï¿½s name for the output folder naming convention.
+		4) The program will then display a new screen where the user will have the option to select specific windows for the output. If the user chooses not to select a window, they can simply select the ï¿½Exitï¿½ option and submit, and the program will automatically terminate. However, if the user 
 		   wishes to select a window, they can choose from the various options provided. For added convenience, hovering over the different options will reveal a hint describing the function of each option, providing guidance for those who may be unsure of which option to select.
 		
 		Four different window options:
-			Continuous Snapshot: This option generates gaze data in a series of fixed, non-overlapping windows.
-			Cumulative Snapshot: This option generates gaze data in a series of expanding windows that increases with every interval.
-			Overlapping Snapshot: This option generates gaze data in a series of fixed and overlapping windows.
-			Event Analytics: This option generates a baseline file based on the first two minutes of the gaze data, and then compares it to the rest of the file. If the data exceeds the baseline value, it will be counted as an event, and the program will continue to search for the next event within a 
+			Gaze Digests: This option generates gaze data in a series of fixed, non-overlapping windows.
+			Cumulative Gaze: This option generates gaze data in a series of expanding windows that increases with every interval.
+			Gaze Snapshots: This option generates gaze data in a series of fixed and overlapping windows.
+			Gaze Events: This option generates a baseline file based on the first two minutes of the gaze data, and then compares it to the rest of the file. If the data exceeds the baseline value, it will be counted as an event, and the program will continue to search for the next event within a 
 							 specified time period. If no event is found, the program will close at a specific period. If another event is found, the session window will continue searching.
 
 		5) Depending on the option you selected, the program will ask for different input. For the first three options, the program will ask you to select the window size and/or overlapping amount (both in terms of time in seconds).
@@ -94,8 +94,8 @@ Analysis
 			a text file that outlines what was successfully created or any errors that was encountered
 		InputFiles Folder: Updated Fixation and Gaze file
 			included the saccade velocity in both files
-		Snapshot Folder (If yes was selected)
-			contains all the snapshot files
+		Window Folder (If yes was selected)
+			contains all the window files
 
 Limitations
 	1) There are currently some sections of the codebase that rely on hard-coded locations that are specific to the paid version of Gazepoint. To ensure that the program functions correctly, it is important to avoid modifying the Gazepoint files in any way.

--- a/src/analysis/ScanPath.java
+++ b/src/analysis/ScanPath.java
@@ -34,9 +34,9 @@ public class ScanPath {
 	public ScanPath(String fixationFile, String outputPath)
 	{
 		this.fixationFile = fixationFile;
-		File snapshotFolder = new File(outputPath + "/ScanPathFolder/");
+		File scanPathFolder = new File(outputPath + "/ScanPathFolder/");
 		this.outputPath = outputPath + "/ScanPathFolder/";
-		snapshotFolder.mkdir();
+		scanPathFolder.mkdir();
 		parseFile();
 
 	}

--- a/src/analysis/SingleAnalytics.java
+++ b/src/analysis/SingleAnalytics.java
@@ -295,39 +295,39 @@ public class SingleAnalytics {
 		
 		//create folder to put the analysis in
 		String dir = "/results/" + outputFolderPath.substring(outputFolderPath.lastIndexOf("/") + 1) + "/inputFiles/";
-		File snapshotFolder = new File(outputFolderPath + "/" + pName + "_SnapshotFolder");
-		snapshotFolder.mkdir();
-		String outputFolder = snapshotFolder.getPath();
+		File windowFolder = new File(outputFolderPath + "/" + pName + "_WindowFolder");
+		windowFolder.mkdir();
+		String outputFolder = windowFolder.getPath();
 		
 		GridBagConstraints c = new GridBagConstraints();
 		ButtonGroup bg = new ButtonGroup();
 		
 		JLabel qLabel = new JLabel("Please pick an option");		
 		JPanel optionsPanel = new JPanel(new FlowLayout());
-		JRadioButton continuousSnapshotButton = new JRadioButton("Continuous Snapshot");
-		JRadioButton cumulativeSnapshotButton = new JRadioButton("Cumulative Snapshot");
-		JRadioButton overlappingSnapshotButton = new JRadioButton("Overlapping Snapshot");
-		JRadioButton eventAnalyticsButton = new JRadioButton("Event Analytics");
+		JRadioButton digestsButton = new JRadioButton("Gaze Digests");
+		JRadioButton cumulativeButton = new JRadioButton("Cumulative Gaze");
+		JRadioButton snapshotButton = new JRadioButton("Gaze Snapshots");
+		JRadioButton gazeEventsButton = new JRadioButton("Gaze Events");
 		JRadioButton exitBtn = new JRadioButton("Exit");
 		JButton btn = new JButton("OK");
 
 		qLabel.setFont(new Font("Verdana", Font.PLAIN, 20));
-		continuousSnapshotButton.setToolTipText("This option generates gaze data in a series of fixed, non-overlapping windows");
-		cumulativeSnapshotButton.setToolTipText("This option generates gaze data in a series of expanding windows that increases with every interval");
-		overlappingSnapshotButton.setToolTipText("This option generates gaze data in a series of fixed and overlapping windows");
-		eventAnalyticsButton.setToolTipText("This option generates a baseline file based on the first two minutes of the gaze data, and then compares it to the rest of the file");
+		digestsButton.setToolTipText("This option generates gaze data in a series of fixed, non-overlapping windows");
+		cumulativeButton.setToolTipText("This option generates gaze data in a series of expanding windows that increases with every interval");
+		snapshotButton.setToolTipText("This option generates gaze data in a series of fixed and overlapping windows");
+		gazeEventsButton.setToolTipText("This option generates a baseline file based on the first two minutes of the gaze data, and then compares it to the rest of the file");
 		
 		//Adds all the JRadioButton to a layout
-		bg.add(continuousSnapshotButton);
-		bg.add(cumulativeSnapshotButton);
-		bg.add(overlappingSnapshotButton);
-		bg.add(eventAnalyticsButton);
+		bg.add(digestsButton);
+		bg.add(cumulativeButton);
+		bg.add(snapshotButton);
+		bg.add(gazeEventsButton);
 		bg.add(exitBtn);
 		//Adds all the JRadioButton to a a flow layout
-		optionsPanel.add(continuousSnapshotButton);
-		optionsPanel.add(cumulativeSnapshotButton);
-		optionsPanel.add(overlappingSnapshotButton);
-		optionsPanel.add(eventAnalyticsButton);
+		optionsPanel.add(digestsButton);
+		optionsPanel.add(cumulativeButton);
+		optionsPanel.add(snapshotButton);
+		optionsPanel.add(gazeEventsButton);
 		optionsPanel.add(exitBtn);
 		
 		c.gridx = 0;//set the x location of the grid for the next component
@@ -358,17 +358,17 @@ public class SingleAnalytics {
 			c.gridy = 0;
 			panel.add(image,c);
 			
-			if(continuousSnapshotButton.isSelected()||cumulativeSnapshotButton.isSelected())
+			if(digestsButton.isSelected()||cumulativeButton.isSelected())
 			{
-				contCumulWindowAction(c, outputFolder,dir, continuousSnapshotButton.isSelected());
+				gazeDigCumulAction(c, outputFolder,dir, digestsButton.isSelected());
 			}
-			else if(overlappingSnapshotButton.isSelected())
+			else if(snapshotButton.isSelected())
 			{
-				overlappingWindowAction(c, outputFolder,dir);
+				gazeSnapshotAction(c, outputFolder,dir);
 			}
-			else if(eventAnalyticsButton.isSelected())
+			else if(gazeEventsButton.isSelected())
 			{
-				eventWindowAction(c, outputFolder,dir);	
+				gazeEventsAction(c, outputFolder,dir);	
 			}
 		});
 		
@@ -376,14 +376,14 @@ public class SingleAnalytics {
 	}
 
 	/**
-	 * UI for both continuous and cumulative window
+	 * UI for both gaze digests and cumulative gaze windows.
 	 * 
 	 * @param	c					layout type
 	 * @param	outputFolder		the path where the generated files will reside
 	 * @param	dir					sets the directory 
-	 * @param	contiWindowSelect	returns true if the user selected continuous window
+	 * @param	digestWindowSelect	returns true if the user selected gaze digest.
 	 */
-	private static void contCumulWindowAction(GridBagConstraints c, String outputFolder, String dir, boolean contiWindowSelected)
+	private static void gazeDigCumulAction(GridBagConstraints c, String outputFolder, String dir, boolean digestWindowSelected)
 	{
 		JPanel userInputPanel = new JPanel(new FlowLayout());
 		String gazepointFile = modifier.fileChooser("Please select which file you would like to parse out", dir);
@@ -402,11 +402,11 @@ public class SingleAnalytics {
 		panel.revalidate();
 
 		contBtn.addActionListener(ev -> {
-			if(contiWindowSelected)
+			if(digestWindowSelected)
 			{
 				try 
 				{
-					WindowOperations.continuousWindow(gazepointFile, outputFolder,Integer.parseInt(windowSizeInput.getText()) );
+					WindowOperations.digestWindow(gazepointFile, outputFolder,Integer.parseInt(windowSizeInput.getText()) );
 				} 
 				catch (NumberFormatException | CsvValidationException e1) 
 				{
@@ -434,13 +434,13 @@ public class SingleAnalytics {
 	}
 	
 	/**
-	 * UI for overlapping window
+	 * UI for gaze snapshots. Snapshots are partly overlapping windows.
 	 * 
 	 * @param	c					layout type
 	 * @param	outputFolder		the path where the generated files will reside
 	 * @param	dir					sets the directory 
 	 */
-	private static void overlappingWindowAction(GridBagConstraints c, String outputFolder, String dir)
+	private static void gazeSnapshotAction(GridBagConstraints c, String outputFolder, String dir)
 	{
 		JPanel userInputPanel0 = new JPanel(new FlowLayout());
 		JPanel userInputPanel1 = new JPanel(new FlowLayout());
@@ -468,7 +468,7 @@ public class SingleAnalytics {
 		overlappingBtn.addActionListener(ev -> {
 			try 
 			{
-				WindowOperations.overlappingWindow(gazepointFile, outputFolder,Integer.parseInt(windowSizeInput.getText()), Integer.parseInt(overlappingInput.getText()) );
+				WindowOperations.snapshotWindow(gazepointFile, outputFolder,Integer.parseInt(windowSizeInput.getText()), Integer.parseInt(overlappingInput.getText()) );
 			} 
 			catch (NumberFormatException | CsvValidationException e1) 
 			{
@@ -481,13 +481,13 @@ public class SingleAnalytics {
 	}
 	
 	/**
-	 * UI for event window
+	 * UI for gaze events.
 	 * 
 	 * @param	c					layout type
 	 * @param	outputFolder		the path where the generated files will reside
 	 * @param	dir					sets the directory 
 	 */
-	private static void eventWindowAction(GridBagConstraints c, String outputFolder, String dir)
+	private static void gazeEventsAction(GridBagConstraints c, String outputFolder, String dir)
 	{
 		String gazepointFilePath = modifier.fileChooser("Please select your gaze file", dir);
 		String baselineFilePath = outputFolderPath + "/baseline.csv";

--- a/src/analysis/WindowOperations.java
+++ b/src/analysis/WindowOperations.java
@@ -16,29 +16,29 @@ import com.opencsv.exceptions.CsvValidationException;
 public class WindowOperations {
 
 	/**
-	 * Creates CSV files by dividing the data into nonoverlapping, fixed-size windows
+	 * Creates CSV files by dividing the data into nonoverlapping, fixed-size windows called digests.
 	 *  
 	 * @param inputFile		path of the input file that contains the data 
 	 * @param outputFolder 	path of the output folder where the windowed data will be stored
 	 * @param windowSize 	value that specifies the size of the window to be used in the operation
 	 * @throws CsvValidationException
 	 */
-	public static void continuousWindow(String inputFile, String outputFolder, int windowSize) throws CsvValidationException
+	public static void digestWindow(String inputFile, String outputFolder, int windowSize) throws CsvValidationException
 	{
 		int endTime = windowSize;
 		int initialTime = 0;
-		String outputFile = "/continuous_" + endTime + ".csv";
+		String outputFile = "/digest_" + endTime + ".csv";
 		try {
-			while(snapshot(inputFile,outputFile, outputFolder, initialTime,endTime))
+			while(gazeWindow(inputFile,outputFile, outputFolder, initialTime,endTime))
 			{
 				initialTime += windowSize;
 				endTime += windowSize;
-				outputFile = "/continuous_" + endTime + ".csv";
+				outputFile = "/digest_" + endTime + ".csv";
 			}
 		} 
 		catch (IOException e) 
 		{
-			 systemLogger.writeToSystemLog(Level.WARNING, WindowOperations.class.getName(), "Error with continuous window output " + outputFile + "\n" + e.toString());
+			 systemLogger.writeToSystemLog(Level.WARNING, WindowOperations.class.getName(), "Error with digest window output " + outputFile + "\n" + e.toString());
 		}
 
 	}
@@ -59,7 +59,7 @@ public class WindowOperations {
 		String outputFile = "/cumulative_" + endTime + ".csv";
 		try 
 		{
-			while(snapshot(inputFile,outputFile,outputFolder,initialTime,endTime))
+			while(gazeWindow(inputFile,outputFile,outputFolder,initialTime,endTime))
 			{
 				endTime += windowSize;
 				outputFile = "/cumulative_" + endTime + ".csv";
@@ -72,7 +72,7 @@ public class WindowOperations {
 	}
 	
 	/**
-	 * Creates CSV files by dividing the data into overlapping, fixed-size windows. 
+	 * Creates CSV files by dividing the data into overlapping, fixed-size windows called snapshots. 
 	 * The user has the ability to customize the degree of overlap and the size of the windows according to their preferences. 
 	 * 
 	 * @param inputFile		path of the input file that contains the data 
@@ -81,23 +81,23 @@ public class WindowOperations {
 	 * @param overlap		value the specifies the size of the overlap 
 	 * @throws CsvValidationException
 	 */
-	public static void overlappingWindow(String inputFile, String outputFolder, int windowSize, int overlap) throws CsvValidationException
+	public static void snapshotWindow(String inputFile, String outputFolder, int windowSize, int overlap) throws CsvValidationException
 	{
 		int endTime = windowSize;
 		int initialTime = 0;
-		String outputFile = outputFolder + "/overlap_" + endTime + ".csv";
+		String outputFile = outputFolder + "/snapshot_" + endTime + ".csv";
 		try {
-			while(snapshot(inputFile,outputFile,outputFolder,initialTime,endTime))
+			while(gazeWindow(inputFile,outputFile,outputFolder,initialTime,endTime))
 			{
 				initialTime = endTime - overlap;
 				endTime += windowSize;
-				outputFile = "/overlap_" + endTime + ".csv";
+				outputFile = "/snapshot_" + endTime + ".csv";
 				
 			}
 		} 
 		catch (IOException e) 
 		{
-			 systemLogger.writeToSystemLog(Level.WARNING, WindowOperations.class.getName(), "Error with overlapping window output " + outputFile + "\n" + e.toString());
+			 systemLogger.writeToSystemLog(Level.WARNING, WindowOperations.class.getName(), "Error with snapshot window output " + outputFile + "\n" + e.toString());
 		}
 	}
 	
@@ -109,7 +109,7 @@ public class WindowOperations {
 	 * @param outputFolderPath		path of the output folder where the windowed data will be stored
 	 * @param baselineFilePath 		path of the baseline file
 	 * @param baselineHeaderIndex	the index of the selected value in the baseline file 
-	 * @param inputHeaderIndex		the index of the selected value in the selected file 
+	 * @param inputHeaderIndex		the index of the selected value in the selected fileï¿½
 	 * @param maxDur				the max duration an event can continue
 	 * @throws IOException
 	 */
@@ -230,7 +230,7 @@ public class WindowOperations {
 	}
 	
 	/**
-	 * creates a CSV file containing all of the data points within the given start and end times based on the input file
+	 * creates a CSV file containing all of the data points within the given start and end times based on the input file.
 	 * 
 	 * @param inputFile		the CSV file containing the data points that will be copied
 	 * @param fileName		the name of the input CSV file
@@ -239,71 +239,71 @@ public class WindowOperations {
 	 * @param end			the end time
 	 * @return	boolean		true if the program was able to successfully execute it, false otherwise
 	 */
-	private static boolean snapshot(String inputFile, String fileName, String outputFolder, int start, int end) throws IOException, CsvValidationException
+	private static boolean gazeWindow(String inputFile, String fileName, String outputFolder, int start, int end) throws IOException, CsvValidationException
 	{
 		String outputFile = outputFolder + fileName;
 		FileWriter outputFileWriter = new FileWriter(new File (outputFile));
-        CSVWriter outputCSVWriter = new CSVWriter(outputFileWriter);
-        FileReader fileReader = new FileReader(inputFile);
-        CSVReader csvReader = new CSVReader(fileReader);
+		CSVWriter outputCSVWriter = new CSVWriter(outputFileWriter);
+		FileReader fileReader = new FileReader(inputFile);
+		CSVReader csvReader = new CSVReader(fileReader);
 
-        try 
-        {
-        	//header
-             String[]nextLine = csvReader.readNext();
-             outputCSVWriter.writeNext(nextLine);
-             
-             int timestampIndex = -1;
-             for(int i = 0; i < nextLine.length; i++)
-             {
-            	 if(nextLine[i].contains("TIME("))
-            	 {
-            		 timestampIndex = i;
-            		 break;
-            	 }
-             }
-             
-             while((nextLine = csvReader.readNext()) != null) 
-             {
-            	 if(Double.valueOf(nextLine[timestampIndex]) < start)
-            	 {
-            		 continue;
-            	 }
-            	 else if(Double.valueOf(nextLine[timestampIndex]) > end)
-            	 {
-            		 break;
-            	 }
-            	 else
-            	 {
-            		 outputCSVWriter.writeNext(nextLine);
-            	 }
-             }
+		try 
+		{
+		//header
+				String[]nextLine = csvReader.readNext();
+				outputCSVWriter.writeNext(nextLine);
+				
+				int timestampIndex = -1;
+				for(int i = 0; i < nextLine.length; i++)
+				{
+					if(nextLine[i].contains("TIME("))
+					{
+						timestampIndex = i;
+						break;
+					}
+				}
+				
+				while((nextLine = csvReader.readNext()) != null) 
+				{
+					if(Double.valueOf(nextLine[timestampIndex]) < start)
+					{
+						continue;
+					}
+					else if(Double.valueOf(nextLine[timestampIndex]) > end)
+					{
+						break;
+					}
+					else
+					{
+						outputCSVWriter.writeNext(nextLine);
+					}
+				}
 
-             if((nextLine = csvReader.readNext()).equals(null))
-             {
-            	 return false;
-             }
-             
-     		systemLogger.writeToSystemLog(Level.INFO, WindowOperations.class.getName(), "Successfully created file " + outputFile );
-        }
-        catch(NullPointerException ne)
-        {
-        	System.out.println("done writing file: " + outputFile);
-        	outputCSVWriter.close();
-        	return false;
-        }
-        catch(Exception e)
-        {
-    		systemLogger.writeToSystemLog(Level.SEVERE, WindowOperations.class.getName(), "Error with window method  " + outputFile + "\n" + e.toString());
-    		System.exit(0);
+				if((nextLine = csvReader.readNext()).equals(null))
+				{
+					return false;
+				}
+				
+		systemLogger.writeToSystemLog(Level.INFO, WindowOperations.class.getName(), "Successfully created file " + outputFile );
+		}
+		catch(NullPointerException ne)
+		{
+		System.out.println("done writing file: " + outputFile);
+		outputCSVWriter.close();
+		return false;
+		}
+		catch(Exception e)
+		{
+		systemLogger.writeToSystemLog(Level.SEVERE, WindowOperations.class.getName(), "Error with window method  " + outputFile + "\n" + e.toString());
+		System.exit(0);
 
-        }
-        finally
-        {
-            outputCSVWriter.close();
-            csvReader.close();
-        }
-        return true;
+		}
+		finally
+		{
+			outputCSVWriter.close();
+			csvReader.close();
+		}
+		return true;
 	}
 	
 	

--- a/src/analysis/WindowOperations.java
+++ b/src/analysis/WindowOperations.java
@@ -85,7 +85,7 @@ public class WindowOperations {
 	{
 		int endTime = windowSize;
 		int initialTime = 0;
-		String outputFile = outputFolder + "/snapshot_" + endTime + ".csv";
+		String outputFile = "/snapshot_" + endTime + ".csv";
 		try {
 			while(gazeWindow(inputFile,outputFile,outputFolder,initialTime,endTime))
 			{
@@ -125,21 +125,21 @@ public class WindowOperations {
 		
 		
 		FileWriter outputFileWriter = new FileWriter(new File (outputFile));
-        CSVWriter outputCSVWriter = new CSVWriter(outputFileWriter);
-        FileReader inputFileReader = new FileReader(inputFilePath);
-        CSVReader inputCSVReader = new CSVReader(inputFileReader);
-        FileReader baselineFileReader = new FileReader(baselineFilePath);
-        CSVReader baselineCSVReader = new CSVReader(baselineFileReader);
-        //Grabs the baseline value based on the chosen header
+		CSVWriter outputCSVWriter = new CSVWriter(outputFileWriter);
+		FileReader inputFileReader = new FileReader(inputFilePath);
+		CSVReader inputCSVReader = new CSVReader(inputFileReader);
+		FileReader baselineFileReader = new FileReader(baselineFilePath);
+		CSVReader baselineCSVReader = new CSVReader(baselineFileReader);
+		//Grabs the baseline value based on the chosen header
 
-        try
-        {	
+		try
+		{	
 
-        	//headers
-            String[]nextLine = baselineCSVReader.readNext();
-            nextLine = baselineCSVReader.readNext();
-            baseline = Double.valueOf(nextLine[baselineHeaderIndex]);
-        }
+		//headers
+			String[]nextLine = baselineCSVReader.readNext();
+			nextLine = baselineCSVReader.readNext();
+			baseline = Double.valueOf(nextLine[baselineHeaderIndex]);
+		}
         catch (Exception e)
         {
     		systemLogger.writeToSystemLog(Level.SEVERE, WindowOperations.class.getName(), "Error with event window baseline reading " + outputFile + "\n" + e.toString());
@@ -198,8 +198,8 @@ public class WindowOperations {
 	        			outputFile = outputFolderPath + "/event_" + index + ".csv";
 	        			outputCalcFile = outputFolderPath + "/eventCalc_" + index + ".csv";
 	        			outputFileWriter = new FileWriter(new File (outputFile));
-	        	        outputCSVWriter = new CSVWriter(outputFileWriter);
-	        	        outputCSVWriter.writeNext(header);
+						outputCSVWriter = new CSVWriter(outputFileWriter);
+						outputCSVWriter.writeNext(header);
 	        		}
         		}
         		else
@@ -250,53 +250,52 @@ public class WindowOperations {
 		try 
 		{
 		//header
-				String[]nextLine = csvReader.readNext();
-				outputCSVWriter.writeNext(nextLine);
-				
-				int timestampIndex = -1;
-				for(int i = 0; i < nextLine.length; i++)
+			String[]nextLine = csvReader.readNext();
+			outputCSVWriter.writeNext(nextLine);
+			
+			int timestampIndex = -1;
+			for(int i = 0; i < nextLine.length; i++)
+			{
+				if(nextLine[i].contains("TIME("))
 				{
-					if(nextLine[i].contains("TIME("))
-					{
-						timestampIndex = i;
-						break;
-					}
+					timestampIndex = i;
+					break;
 				}
-				
-				while((nextLine = csvReader.readNext()) != null) 
+			}
+			
+			while((nextLine = csvReader.readNext()) != null) 
+			{
+				if(Double.valueOf(nextLine[timestampIndex]) < start)
 				{
-					if(Double.valueOf(nextLine[timestampIndex]) < start)
-					{
-						continue;
-					}
-					else if(Double.valueOf(nextLine[timestampIndex]) > end)
-					{
-						break;
-					}
-					else
-					{
-						outputCSVWriter.writeNext(nextLine);
-					}
+					continue;
 				}
+				else if(Double.valueOf(nextLine[timestampIndex]) > end)
+				{
+					break;
+				}
+				else
+				{
+					outputCSVWriter.writeNext(nextLine);
+				}
+			}
 
-				if((nextLine = csvReader.readNext()).equals(null))
-				{
-					return false;
-				}
+			if((nextLine = csvReader.readNext()).equals(null))
+			{
+				return false;
+			}
 				
-		systemLogger.writeToSystemLog(Level.INFO, WindowOperations.class.getName(), "Successfully created file " + outputFile );
+			systemLogger.writeToSystemLog(Level.INFO, WindowOperations.class.getName(), "Successfully created file " + outputFile );
 		}
 		catch(NullPointerException ne)
 		{
-		System.out.println("done writing file: " + outputFile);
-		outputCSVWriter.close();
-		return false;
+			System.out.println("done writing file: " + outputFile);
+			outputCSVWriter.close();
+			return false;
 		}
 		catch(Exception e)
 		{
-		systemLogger.writeToSystemLog(Level.SEVERE, WindowOperations.class.getName(), "Error with window method  " + outputFile + "\n" + e.toString());
-		System.exit(0);
-
+			systemLogger.writeToSystemLog(Level.SEVERE, WindowOperations.class.getName(), "Error with window method  " + outputFile + "\n" + e.toString());
+			System.exit(0);
 		}
 		finally
 		{
@@ -305,7 +304,5 @@ public class WindowOperations {
 		}
 		return true;
 	}
-	
-	
 	
 }

--- a/src/analysis/helpPg.txt
+++ b/src/analysis/helpPg.txt
@@ -7,19 +7,19 @@ How to use the Data Analysis Page
 	2) Once you submit these,  the program will then display a new screen where the user will have the option to select specific windows for the output
 		a) If you do not want to select a window than you can simply choose the exit option and the program will terminate
 		b) There are four different window option you can choose from 
-			a)Continuous Snapshot: This option generates gaze data in a series of fixed, non-overlapping windows
-			b)Cumulative Snapshot: This option generates gaze data in a series of expanding windows that increases with every interval.
-			c)Overlapping Snapshot: This option generates gaze data in a series of fixed and overlapping windows
-			d)Event Analytics: his option generates a baseline file based on the first two minutes of the gaze data, and then compares it to the rest of the file. 
+			a)Gaze Digests: This option generates gaze data in a series of fixed, non-overlapping windows
+			b)Cumulative Gaze: This option generates gaze data in a series of expanding windows that increases with every interval.
+			c)Gaze Snapshots: This option generates gaze data in a series of fixed and overlapping windows
+			d)Gaze Events: his option generates a baseline file based on the first two minutes of the gaze data, and then compares it to the rest of the file. 
 			  If the data exceeds the baseline value, it will be counted as an event, and the program will continue to search for the next event within a specified 
 			  time period. If no event is found, the program will close at a specific period. If another event is found, the session window will continue searching
 	3) The prompt will then ask you to pick a file to use
 	4) Depending on what you selected, the program will prompt you to provide additional parameters specific to that window.
-		a)Continuous Snapshot and Cumulative Snapshot: The program will ask for a Window size in seconds. This is how the program is going to break up your file
+		a)Gaze Digests and Cumulative Gaze: The program will ask for a Window size in seconds. This is how the program is going to break up your file
 		  into sections. 
-		b)Overlapping Snapshot:The program will ask for a Window size and an overlapping amount in seconds. Not including the first file, the rest of your snapshot
+		b)Gaze Snapshots:The program will ask for a Window size and an overlapping amount in seconds. Not including the first file, the rest of your snapshot
 		  files will have overlapping values according to the overlapping input.
-		c)Event Analytics: The program will ask you to pick two values you would like to compare. One will come from an auto-generated file based on how the 
+		c)Gaze Events: The program will ask you to pick two values you would like to compare. One will come from an auto-generated file based on how the 
 		  participant performed in the first two minutes. The second will be from the file you picked. Please make sure the inputs correlate with one another,
 		  if not the calculations will be incorrect. You would also asked to define the maximum duration of an event in seconds. If there is no event trigger 
 		  within that amount of time, the event will automatically end.

--- a/src/wekaext/CSVFinder.java
+++ b/src/wekaext/CSVFinder.java
@@ -6,10 +6,10 @@ import java.util.Scanner;
 import java.util.regex.*;
 
 public class CSVFinder {
-//	This program will merge all the participants snapshots correlating to the 
+//	This program will merge all the participants gaze windows correlating to the 
 //	window size must create folder where you want data stored before running this
 	
-//	root directory refers to the folder with all participants folders and their snapshots
+//	root directory refers to the folder with all participants folders and their gaze windows.
 
 	public static void main(String[] args) {
 		

--- a/src/wekaext/CSVMerger.java
+++ b/src/wekaext/CSVMerger.java
@@ -4,7 +4,7 @@ import java.io.*;
 import java.util.*;
 
 public class CSVMerger {
-//	This program will compile all the snapshots in Expanding_Windows to 1 CSV File
+//	This program will compile all the windows in Expanding_Windows to 1 CSV File
 //	It will do this for all subdirectories (e.g. Expanding_Windows_by_Xplane_Score_#min)
 	
 	public static void main(String[] args) throws IOException {


### PR DESCRIPTION
Renamed windows to match original research paper

> gaze digests (non-overlapping scheduled data), gaze events (non-overlapping and non-scheduled data based on significant gaze events detected during interaction), gaze snapshots (partly overlapping data capturing the most recent state of user gaze), and cumulative gaze (entirely overlapping data capturing all known gaze of a user)

Changes to window are as such (old name -> new name):
* continuous snapshot -> gaze digests
* event analytics -> gaze events
* overlapping snapshots -> gaze snapshots
* cumulative snapshot -> cumulative gaze

I also:
* renamed snapshotFolder to windowFolder
* renamed shapshot() to gazeWindow()
* fixed the broken function that created snapshots (WindowOperations.java line 88)
* changed some indentation to line up better (gave up because tabs and spaces are mixed 😢)


