### PR TITLE
Fix saccade duration

### DIFF
--- a/src/analysis/AOI.java
+++ b/src/analysis/AOI.java
@@ -83,11 +83,11 @@ public class AOI {
 			// fixation columns
 			headers.add("total number of fixations");
 			headers.add("sum of all fixation duration");
-			headers.add("mean fixation duration (ms)");
-			headers.add("median fixation duration (ms)");
-			headers.add(" StDev of fixation durations (ms)");
-			headers.add("Min. fixation duration (ms)");
-			headers.add("Max. fixation duration (ms)");
+			headers.add("mean fixation duration (s)");
+			headers.add("median fixation duration (s)");
+			headers.add(" StDev of fixation durations (s)");
+			headers.add("Min. fixation duration (s)");
+			headers.add("Max. fixation duration (s)");
 
 			// saccade columns
 			headers.add("total number of saccades");
@@ -97,12 +97,12 @@ public class AOI {
 			headers.add("StDev of saccade lengths");
 			headers.add("min saccade length");
 			headers.add("max saccade length");
-			headers.add("sum of all saccade durations");
-			headers.add("mean saccade duration");
-			headers.add("median saccade duration");
-			headers.add("StDev of saccade durations");
-			headers.add("Min. saccade duration");
-			headers.add("Max. saccade duration");
+			headers.add("sum of all saccade durations (s)");
+			headers.add("mean saccade duration (s)");
+			headers.add("median saccade duration (s)");
+			headers.add("StDev of saccade durations (s)");
+			headers.add("Min. saccade duration (s)");
+			headers.add("Max. saccade duration (s)");
 
 			// fixation v. saccade
 			headers.add("scanpath duration");
@@ -469,7 +469,7 @@ public class AOI {
 					if (aoiName.equals(prevAoiName)) {
 						continue;
 					}
-					else if (!aoiMap.containsKey(prevAoiName)) {
+					else if (aoiMap.containsKey(prevAoiName)) {
 						String aoiPair = prevAoiName + " -> " + aoiName;
 						aoiTransitions.put(aoiPair, aoiTransitions.getOrDefault(aoiPair, 0)+1);
 					}
@@ -547,22 +547,18 @@ public class AOI {
 		int peakVelocityIndex = -1;
 		int blinkIdIndex = -1;
 
-			/*
+	/*
 	 * Modifies an Indexes object to have indexes are important data columns in the csv file.
 	 */
 		private void findIndexes(String[] headers) {
 		// Locate the indexes for required fields
 			for (int i = 0; i < headers.length; i++) {
 				String header = headers[i];
-
-				if (this.timeIndex == -1) {
-					if (header.contains("TIME") && !header.contains("TICK")) {
-						this.timeIndex = i;
-						continue;
-					}
-				}
 				
 				switch(header) {
+					case "FPOGS":
+						this.timeIndex = i;
+						break;
 					case "AOI":
 						this.aoiIndex = i;
 						break;

--- a/src/analysis/WindowOperations.java
+++ b/src/analysis/WindowOperations.java
@@ -306,6 +306,4 @@ public class WindowOperations {
         return true;
 	}
 	
-	
-	
 }

--- a/src/analysis/fixation.java
+++ b/src/analysis/fixation.java
@@ -69,13 +69,7 @@ public class fixation {
             int fixationXIndex = list.indexOf("FPOGX");
             int fixationYIndex = list.indexOf("FPOGY");
             int aoiIndex = list.indexOf("AOI");
-            int timestampIndex = -1;
-         	for(int i = 0; i < nextLine.length; i++)
-         	{
-         		if(nextLine[i].contains("TIME") && timestampIndex == -1) {
-         			timestampIndex = i;
-         		}
-         	}
+            int timestampIndex = list.indexOf("FPOGS");
          	
          	HashMap<String, Double> aoiProbability = new HashMap<String, Double>();
          	HashMap<String, HashMap<String, Double>> transitionProbability = new HashMap<String, HashMap<String, Double>>();

--- a/src/analysis/saccade.java
+++ b/src/analysis/saccade.java
@@ -25,6 +25,8 @@ package analysis;
  */
 
 import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
 
 
 public class saccade {
@@ -48,10 +50,22 @@ public class saccade {
 		//return allLengths;
 	}
 
-	//the saccade duration is the duration between two fixations
-	//e.g. given a fixation A that has timestamp T1 and duration D1,
-	//and a subsequent fixation B that has timestamp T2 and duration T2,
-	//the saccade duration between A and B is: T2-(T1+D1)
+	/**
+	 * Calculates saccade duration between sequential fixatiion.
+	 * The saccade duration is the duration between two fixations
+	 * e.g. given a fixation A that has timestamp T1 and duration D1,
+	 * and a subsequent fixation B that has timestamp T2 and duration T2,
+	 * the saccade duration between A and B is: T2-(T1+D1)
+	 * 
+	 * Note: Gazepoint analysis gives three time data values for each fixation.
+	 * 	TIME: time elapsed in seconds since the last system initialization
+	 * 	TIMETICK: CPU ticks recorded at time as TIME, can be used to synchronize data with other applications
+	 * 	FPOGS: The starting time of the fixation POG in seconds since the system initialization or calibration.
+	 * Make sure to use FPOGS as the timestamp when calculating saccade duration.
+	 * 
+	 * @param saccadeDetails start time, fixation duration, and ID for each fixation
+	 * @returns list of saccade durations in seconds
+	*/
 	public static ArrayList<Double> getAllSaccadeDurations(ArrayList<Double[]> saccadeDetails){
 		ArrayList<Double> allSaccadeDurations = new ArrayList<>();
 		for (int i=0; (i+1)<saccadeDetails.size(); i++){

--- a/src/tests/AOI_tests/AOITester.java
+++ b/src/tests/AOI_tests/AOITester.java
@@ -1,5 +1,6 @@
 package tests.AOI_tests;
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -32,6 +33,7 @@ public class AOITester {
 		fixationFile = currentPath + "/aoi_test_fixations.csv";
 		allGazeFile = currentPath + "/aoi_test_all_gaze.csv";
 		outputFolder = currentPath + "/output/";
+		new File(outputFolder).mkdirs();
 		expectedFolder = currentPath + "/expected_output/";
 		systemLogger.createSystemLog(outputFolder);
 
@@ -71,7 +73,7 @@ public class AOITester {
 			}
 			return true;
 		} catch (IOException e) {
-			systemLogger.writeToSystemLog(Level.WARNING, WindowOperations.class.getName(), "Could not compare " + expectedFile + " and " + testFile);
+			systemLogger.writeToSystemLog(Level.WARNING, AOITester.class.getName(), "Could not compare " + expectedFile + " and " + testFile);
 		}
 		return false;
 	}


### PR DESCRIPTION
Saccade duration is no longer negative.

Note: Gazepoint analysis gives three time data values for each fixation. 
* TIME: time elapsed in seconds since the last system initialization
* TIMETICK: CPU ticks recorded at time as TIME, can be used to synchronize data with other applications
* FPOGS: The starting time of the fixation POG in seconds since the system initialization or calibration.
Now using FPOGS as timestamp to calculate saccade duration. Originally, TIME was used but gave incorrect results. 

I also changed the headings of the csv files to reflect that the data is calculating durations in seconds, not ms. It has always been in seconds and the labels were wrong.