### PR TITLE
Implemented cleaning process

### DIFF
--- a/src/analysis/DataFiltering.java
+++ b/src/analysis/DataFiltering.java
@@ -30,6 +30,55 @@ public class DataFiltering {
         return filtered;
     }
 
+    /**
+     * Cleanses data by filtering out invalid data. Valid data entries must occur within
+     * the bounds of the monitor and have humanly possible pupil dilation.
+     * @param data Data to be cleansed
+     */
+    public static DataEntry filterByValidity(DataEntry data) {
+        // humanly possible pupil diameter is between 2 and 8 mm
+        final int MIN_DIAMETER = 2;
+        final int MAX_DIAMETER = 8;
+        final int MAX_PUPIL_DIFF = 1;   
+        // GazePoint scales point of gaze location from 0 to 1 when on screen
+        final int MIN_SCREEN_DIM = 0;   
+        final int MAX_SCREEN_DIM = 1;   
+
+        DataEntry filtered = new DataEntry(data.getHeaders());
+        for (int rowNum = 0; rowNum < data.rowCount(); rowNum++) {
+            // Note: It is extremely slow to parse a string over and over again
+            // Check if Gazepoint could detect the pupils
+            Boolean leftValid = Integer.parseInt(data.getValue("LPMMV", rowNum)) == 1;
+            Boolean rightValid = Integer.parseInt(data.getValue("RPMMV", rowNum)) == 1;
+            if (!(leftValid && rightValid)) {
+                continue;   // skip invalid entry
+            } 
+            // Check if POG is on the screen
+            float xCoordinate = Float.parseFloat(data.getValue("FPOGX" ,rowNum));
+            float yCoordinate = Float.parseFloat(data.getValue("FPOGY" ,rowNum));
+            if (xCoordinate < MIN_SCREEN_DIM || xCoordinate > MAX_SCREEN_DIM) {
+                continue; // off screen in x-direction, invalid
+            } else if (yCoordinate < MIN_SCREEN_DIM || yCoordinate > MAX_SCREEN_DIM) {
+                continue; // off screen in y-direction, invalid entry
+            }
+            // Check if pupils are valid sizes individually and compared to each other.
+            float leftDiameter = Float.parseFloat(data.getValue("LPMM", rowNum));
+            float rightDiameter = Float.parseFloat(data.getValue("RPMM", rowNum));
+            if (
+                leftDiameter >= MIN_DIAMETER
+                && leftDiameter <= MAX_DIAMETER
+                && rightDiameter >= MIN_DIAMETER
+                && rightDiameter <= MAX_DIAMETER
+                && (Math.abs(leftDiameter-rightDiameter) <= MAX_PUPIL_DIFF)
+            ) {
+                filtered.process(data.getRow(rowNum));
+                continue;
+            }
+        }
+        return filtered;
+    }
+
+
     static public LinkedHashMap<String, Data> filterByAOI(DataEntry data ){
         
         return new LinkedHashMap<String, Data>();

--- a/src/analysis/DescriptiveStats.java
+++ b/src/analysis/DescriptiveStats.java
@@ -1,0 +1,161 @@
+package analysis;
+/*
+ * Copyright (c) 2013, Bo Fu
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+
+
+public class DescriptiveStats {
+
+	public static double getSumOfIntegers(ArrayList<Integer> allIntegers){
+
+		double total = 0.0;
+		for (Integer i:allIntegers){
+			total = total + i;
+		}
+		return total;
+	}
+
+	public static double getSumOfDoubles(ArrayList<Double> allDoubles){
+		double total = 0.0;
+		for (Double value : allDoubles) {
+			total += value;
+		}
+
+		return total;
+	}
+
+	public static double getSum(Double[] allDoubles){
+
+		double total = 0.0;
+		for (Double i:allDoubles){
+			total = total + i;
+		}
+		return total;
+
+	}
+
+
+	public static double getMeanOfIntegers(ArrayList<Integer> allIntegers){
+		return getSumOfIntegers(allIntegers)/allIntegers.size();
+	}
+
+	public static double getMeanOfDoubles(ArrayList<Double> allDoubles){
+		return getSumOfDoubles(allDoubles)/allDoubles.size();
+	}
+
+	public static double getMean(Double[] allDoubles){
+		double average = getSum(allDoubles)/allDoubles.length;
+		return average;
+	}
+
+	public static double getMedianOfIntegers(ArrayList<Integer> allIntegers){
+		Collections.sort(allIntegers);
+		int middle = allIntegers.size()/2;
+		if(allIntegers.size()%2 == 1){
+			return allIntegers.get(middle);
+		}else{
+			return (allIntegers.get(middle-1) + allIntegers.get(middle))/2.0;
+		}
+	}
+
+	public static double getMedianOfDoubles(ArrayList<Double> allDoubles){
+		Collections.sort(allDoubles);
+		int middle = allDoubles.size()/2;
+		if(allDoubles.size()%2 == 1){
+			return allDoubles.get(middle);
+		}else{
+			return (allDoubles.get(middle-1) + allDoubles.get(middle))/2.0;
+		}
+	}
+
+	public static double getMedian(Double[] allDoubles){
+		Arrays.sort(allDoubles);
+		if (allDoubles.length%2 == 1){
+			return allDoubles[allDoubles.length/2];
+		}else{
+			return (allDoubles[allDoubles.length/2-1] + allDoubles[allDoubles.length/2])/2;
+		}
+
+	}
+
+	public static double getStDevOfIntegers(ArrayList<Integer> allIntegers){
+		double sum = 0;
+		  double mean = getMeanOfIntegers(allIntegers);
+
+		  for (double i : allIntegers){
+				sum += Math.pow((i - mean), 2);
+		  }
+
+		  return Math.sqrt( sum / (allIntegers.size()-1) );
+	}
+
+	public static double getStDevOfDoubles(ArrayList<Double> allDoubles){
+		double sum = 0;
+		double mean = getMeanOfDoubles(allDoubles);
+		for(double i:allDoubles){
+			sum += Math.pow((i-mean), 2);
+		}
+		return Math.sqrt(sum/(allDoubles.size()-1));
+	}
+
+	public static double getStDev(Double[] allDoubles){
+		double sum = 0;
+		  double mean = getMean(allDoubles);
+
+		  for (double i : allDoubles){
+				sum += Math.pow((i - mean), 2);
+		  }
+
+		  return Math.sqrt( sum / (allDoubles.length-1) );
+	}
+
+	public static double getMinOfIntegers(ArrayList<Integer> allIntegers){
+		return Collections.min(allIntegers);
+	}
+
+	public static double getMinOfDoubles(ArrayList<Double> allDoubles){
+		return Collections.min(allDoubles);
+	}
+
+	public static double getMin(Double[] allDoubles){
+		return Collections.min(Arrays.asList(allDoubles));
+	}
+
+	public static double getMaxOfIntegers(ArrayList<Integer> allIntegers){
+		return Collections.max(allIntegers);
+	}
+
+	public static double getMaxOfDoubles(ArrayList<Double> allDoubles){
+		return Collections.max(allDoubles);
+	}
+
+	public static double getMax(Double[] allDoubles){
+		return Collections.max(Arrays.asList(allDoubles));
+	}
+
+}

--- a/src/analysis/Main.java
+++ b/src/analysis/Main.java
@@ -1,0 +1,7 @@
+package analysis;
+
+public class Main {
+    public static void main(String[] args) {
+        new UserInterface();
+    }
+}


### PR DESCRIPTION
- New filter checks that pupil size is humanly possible and checks that gaze entry occurred within the bounds of the monitor (i.e. person was looking a the screen).  
- The old algorithm always removed the first data entry, but I did not because I was unsure if that would always be correct in the refactor code. I believe it had to do with how Saccade Velocity is calculated but that is no longer included in the cleansing/filtering process. Appending Saccade Velocity should be done in another method, outside the `DataFiltering.java` file because it isn't filtering related.
- Tested by running p10's fixation and all_gaze files through the old code and the new `filterByValidity` method. The `CNT` and `FPOGID` columns were compared from the new and old outputs. The only discrepancy between the files was that the old code removed the first entry as previously mentioned.
- Also capitalized the file names to match the class names contained in the files. Case sensitive operating systems (i.e. UNIX based ones) show a syntax error if the file capitalization do not match. I used `git mv` so commit history should be maintained.