### PR TITLE
Fixed typo in event options

### DIFF
--- a/src/analysis/Windows.java
+++ b/src/analysis/Windows.java
@@ -21,7 +21,7 @@ public class Windows {
         Arrays.asList(
         "FPOGD",
         "SACCADE_MAG",
-        "SACCADE_DUR" 
+        "SACCADE_DIR" 
     ));
 
     // Set of supported events that utilize the allGaze file


### PR DESCRIPTION
SACCADE_DUR should be SACCADE_DIR, for saccade direction (the angle between each fixation in degrees from horizontal).