### PR TITLE
Fix Blink Rate per Minute

### DIFF
--- a/src/analysis/Analysis.java
+++ b/src/analysis/Analysis.java
@@ -173,6 +173,10 @@ public class Analysis {
         results.get(0).addAll(entropy.keySet());
         results.get(1).addAll(entropy.values());
 
+        LinkedHashMap<String, String> blinks = Blinks.analyze(allGaze);
+        results.get(0).addAll(blinks.keySet());
+        results.get(1).addAll(blinks.values());
+
         LinkedHashMap<String,String> gaze = Gaze.analyze(validGaze);
         results.get(0).addAll(gaze.keySet());
         results.get(1).addAll(gaze.values());

--- a/src/analysis/Blinks.java
+++ b/src/analysis/Blinks.java
@@ -1,0 +1,48 @@
+package analysis;
+
+import java.util.LinkedHashMap;
+
+public class Blinks {
+   
+   final static String BLINK_ID_INDEX = "BKID";
+   final static String TIME_INDEX = "TIME";
+   final static String DATA_ID_INDEX = "CNT"; // unique for each line of raw data
+   final static String DEFAULT_BKID = "0"; // BKID when no blink is detected
+
+   static public LinkedHashMap<String,String> analyze(DataEntry allGazeData) {
+
+      LinkedHashMap<String,String> results = new LinkedHashMap<String,String>();
+      int blinkCnt = 0;
+      double timeTotal = 0;
+      String prevBlinkId = "";
+      double prevTimestamp = 0;
+      int prevDataId = -10; // IDs are always non-negative
+      for (int i = 0; i < allGazeData.rowCount(); i++) {
+         int curDataId = Integer.parseInt(allGazeData.getValue(DATA_ID_INDEX, i));
+         double curTimestamp = Double.parseDouble(allGazeData.getValue(TIME_INDEX, i));
+         // calculate time window between data records if they are consecutive
+         if (curDataId == prevDataId + 1) {                    
+            timeTotal += curTimestamp - prevTimestamp; 
+         }
+
+         String curBlinkId = allGazeData.getValue(BLINK_ID_INDEX, i);
+         if (!curBlinkId.equals(DEFAULT_BKID) && !curBlinkId.equals(prevBlinkId)) {
+            blinkCnt++; // new blink occurred
+         }
+
+         // update values each loop
+         prevDataId = curDataId;
+         prevTimestamp = curTimestamp;
+         prevBlinkId = curBlinkId;
+      }
+
+      double blinkRate = timeTotal > 0 ? (blinkCnt / timeTotal) * 60 : Double.NaN;
+
+      results.put(
+         "Average Blink Rate per Minute", //Output Header
+         String.valueOf(blinkRate)
+      );  
+
+      return results;   // return LinkedHashMap for consistency even though only 1 result
+   }
+}

--- a/src/analysis/Blinks.java
+++ b/src/analysis/Blinks.java
@@ -36,13 +36,23 @@ public class Blinks {
          prevBlinkId = curBlinkId;
       }
 
+      /*
+         Note: Blink rate can be NaN while blinkCnt can be a non-zero number
+         due to the time window calculations. This is unlikely at 150 Hz because
+         blinks last 0.1-0.4 seconds and a sample is taken every 0.006 seconds. 
+       */
       double blinkRate = timeTotal > 0 ? (blinkCnt / timeTotal) * 60 : Double.NaN;
+
+      results.put(
+         "Total Number of Blinks",
+         String.valueOf(blinkCnt)
+      );
 
       results.put(
          "Average Blink Rate per Minute", //Output Header
          String.valueOf(blinkRate)
       );  
 
-      return results;   // return LinkedHashMap for consistency even though only 1 result
+      return results;
    }
 }

--- a/src/analysis/Gaze.java
+++ b/src/analysis/Gaze.java
@@ -34,11 +34,6 @@ public class Gaze {
         double rightAverage = rightSum / count;
         double bothAverage = bothSum / count;
 
-        results.put(
-            "Average Blink Rate per Minute", //Output Header
-            String.valueOf(totalBlinks / minutes)
-            );   
-
         //Absolute Degrees
         results.put(
             "total number of valid recordings", //Output Header

--- a/src/analysis/Gaze.java
+++ b/src/analysis/Gaze.java
@@ -5,16 +5,12 @@ import java.util.LinkedHashMap;
 public class Gaze {
     final static String PUPIL_LEFT_DIAMETER_INDEX = "LPMM";
     final static String PUPIL_RIGHT_DIAMETER_INDEX = "RPMM";
-    final static String BLINK_INDEX = "BKPMIN";
-    final static String TIME_INDEX = "TIME";
 
     static public LinkedHashMap<String,String> analyze(DataEntry data) {
         LinkedHashMap<String,String> results = new LinkedHashMap<String,String>();
         double leftSum = 0.0;
         double rightSum = 0.0;
         double bothSum = 0.0;
-        int totalBlinks = 0;
-        int minutes = 1;
         int count = data.rowCount();
 
         for (int row = 0; row < data.rowCount(); row++) {
@@ -24,17 +20,11 @@ public class Gaze {
             leftSum += leftSize;
             rightSum += rightSize;
             bothSum += (leftSize + rightSize) / 2.0;
-
-            if (Double.valueOf(data.getValue(TIME_INDEX, row)) > minutes * 60) {
-                totalBlinks += Integer.valueOf(data.getValue(BLINK_INDEX, row));
-                minutes++;
-            }
         }
         double leftAverage = leftSum / count;
         double rightAverage = rightSum / count;
         double bothAverage = bothSum / count;
 
-        //Absolute Degrees
         results.put(
             "total number of valid recordings", //Output Header
             String.valueOf(data.rowCount())

--- a/src/test/BlinksTest.java
+++ b/src/test/BlinksTest.java
@@ -21,16 +21,16 @@ public class BlinksTest {
    static final List<String> HEADERS = Collections.unmodifiableList(
       Arrays.asList(new String[]{"TIME", "CNT", "BKID"})
    );
-   static final String KEY = "Average Blink Rate per Minute";
+   static final String RATE_KEY = "Average Blink Rate per Minute";
+   static final String TOTAL_KEY = "Total Number of Blinks";
 
    @Test
    public void testBlinksAnalyze_emptyData_BlinkRateOfNaN() {
       DataEntry emptyData = new DataEntry(HEADERS);
-      Map<String, String> actual = Blinks.analyze(emptyData);
-      if (!actual.containsKey(KEY)) {
-         fail(String.format("Does not contain \"%s\"", KEY));
-      }
-      assertTrue(actual.get(KEY).equals("NaN"));
+      Map<String, String> actualMap = Blinks.analyze(emptyData);
+      this.checkKeys(actualMap);
+      assertTrue("Unexpected blink rate.", actualMap.get(RATE_KEY).equals("NaN"));
+      assertTrue("Unexpected number of blinks.", actualMap.get(TOTAL_KEY).equals("0"));
    }
 
    @Test
@@ -42,11 +42,10 @@ public class BlinksTest {
          process(Arrays.asList(new String[]{"0.3", "3", "0"}));
       }};
       Map<String, String> actualMap = Blinks.analyze(emptyData);
-      if (!actualMap.containsKey(KEY)) {
-         fail(String.format("Does not contain \"%s\"", KEY));
-      }
-      double actualBlinkRate = Double.parseDouble(actualMap.get(KEY));
-      assertEquals(0.0, actualBlinkRate, PRECISION);
+      this.checkKeys(actualMap);
+      double actualBlinkRate = Double.parseDouble(actualMap.get(RATE_KEY));
+      assertEquals("Unexpected blink rate.", 0.0, actualBlinkRate, PRECISION);
+      assertTrue("Unexpected number of blinks.", actualMap.get(TOTAL_KEY).equals("0"));
    }
 
    @Test
@@ -58,10 +57,9 @@ public class BlinksTest {
          process(Arrays.asList(new String[]{"0.6", "6", "0"}));
       }};
       Map<String, String> actualMap = Blinks.analyze(data);
-      if (!actualMap.containsKey(KEY)) {
-         fail(String.format("Does not contain \"%s\"", KEY));
-      }
-      assertTrue(actualMap.get(KEY).equals("NaN"));
+      this.checkKeys(actualMap);
+      assertTrue("Unexpected blink rate.", actualMap.get(RATE_KEY).equals("NaN"));
+      assertTrue("Unexpected number of blinks.", actualMap.get(TOTAL_KEY).equals("1"));
    }
    
    @Test
@@ -82,11 +80,10 @@ public class BlinksTest {
          process(Arrays.asList(new String[]{"1.0", "10", "0"}));
       }};
       Map<String, String> actualMap = Blinks.analyze(data);
-      if (!actualMap.containsKey(KEY)) {
-         fail(String.format("Does not contain \"%s\"", KEY));
-      }
-      double actualBlinkRate = Double.parseDouble(actualMap.get(KEY));
-      assertEquals(EXPECTED_BLINK_RATE, actualBlinkRate, PRECISION);
+      this.checkKeys(actualMap);
+      double actualBlinkRate = Double.parseDouble(actualMap.get(RATE_KEY));
+      assertEquals("Unexpected blink rate.",EXPECTED_BLINK_RATE, actualBlinkRate, PRECISION);
+      assertTrue("Unexpected number of blinks.", actualMap.get(TOTAL_KEY).equals("2"));
    }
 
    @Test
@@ -105,10 +102,18 @@ public class BlinksTest {
          process(Arrays.asList(new String[]{"1.0", "10", "0"}));
       }};
       Map<String, String> actualMap = Blinks.analyze(data);
-      if (!actualMap.containsKey(KEY)) {
-         fail(String.format("Does not contain \"%s\"", KEY));
+      this.checkKeys(actualMap);
+      double actualBlinkRate = Double.parseDouble(actualMap.get(RATE_KEY));
+      assertEquals("Unexpected blink rate.", EXPECTED_BLINK_RATE, actualBlinkRate, PRECISION);
+      assertTrue("Unexpected number of blinks.", actualMap.get(TOTAL_KEY).equals("2"));
+   }
+
+   private void checkKeys(Map<String, String> map) {
+      if (!map.containsKey(RATE_KEY)) {
+         fail(String.format("Does not contain \"%s\"", RATE_KEY));
       }
-      double actualBlinkRate = Double.parseDouble(actualMap.get(KEY));
-      assertEquals(EXPECTED_BLINK_RATE, actualBlinkRate, PRECISION);
+      if (!map.containsKey(TOTAL_KEY)) {
+         fail(String.format("Does not contain \"%s\"", TOTAL_KEY));
+      }
    }
 }

--- a/src/test/BlinksTest.java
+++ b/src/test/BlinksTest.java
@@ -1,0 +1,114 @@
+package test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+import analysis.Blinks;
+import analysis.DataEntry;
+
+public class BlinksTest {
+   // Note: test values are picked for easy hand calculations, not from from real data.
+
+   final double PRECISION = 0.000000001; // allowable floating point error
+   static final List<String> HEADERS = Collections.unmodifiableList(
+      Arrays.asList(new String[]{"TIME", "CNT", "BKID"})
+   );
+   static final String KEY = "Average Blink Rate per Minute";
+
+   @Test
+   public void testBlinksAnalyze_emptyData_BlinkRateOfNaN() {
+      DataEntry emptyData = new DataEntry(HEADERS);
+      Map<String, String> actual = Blinks.analyze(emptyData);
+      if (!actual.containsKey(KEY)) {
+         fail(String.format("Does not contain \"%s\"", KEY));
+      }
+      assertTrue(actual.get(KEY).equals("NaN"));
+   }
+
+   @Test
+   public void testBlinksAnalyze_noBlinks_BlinkRateOfZero() {
+      DataEntry emptyData = new DataEntry(HEADERS) {{
+         process(Arrays.asList(new String[]{"0.0", "0", "0"}));
+         process(Arrays.asList(new String[]{"0.1", "1", "0"}));
+         process(Arrays.asList(new String[]{"0.2", "2", "0"}));
+         process(Arrays.asList(new String[]{"0.3", "3", "0"}));
+      }};
+      Map<String, String> actualMap = Blinks.analyze(emptyData);
+      if (!actualMap.containsKey(KEY)) {
+         fail(String.format("Does not contain \"%s\"", KEY));
+      }
+      double actualBlinkRate = Double.parseDouble(actualMap.get(KEY));
+      assertEquals(0.0, actualBlinkRate, PRECISION);
+   }
+
+   @Test
+   public void testBlinksAnalyze_noConsecutiveDataRecords_BlinkRateOfNaN() {
+      DataEntry data = new DataEntry(HEADERS) {{
+         process(Arrays.asList(new String[]{"0.0", "0", "0"}));
+         process(Arrays.asList(new String[]{"0.2", "2", "1"}));
+         process(Arrays.asList(new String[]{"0.4", "4", "0"}));
+         process(Arrays.asList(new String[]{"0.6", "6", "0"}));
+      }};
+      Map<String, String> actualMap = Blinks.analyze(data);
+      if (!actualMap.containsKey(KEY)) {
+         fail(String.format("Does not contain \"%s\"", KEY));
+      }
+      assertTrue(actualMap.get(KEY).equals("NaN"));
+   }
+   
+   @Test
+   public void testBlinksAnalyze_duplicateBlinkIdContinuousData() {
+      // 2 blinks in 1 second => (2/1)*60 = 120 blinks per minute
+      final double EXPECTED_BLINK_RATE = 120;
+      DataEntry data = new DataEntry(HEADERS) {{
+         process(Arrays.asList(new String[]{"0.0", "0", "0"}));
+         process(Arrays.asList(new String[]{"0.1", "1", "0"}));
+         process(Arrays.asList(new String[]{"0.2", "2", "1"}));
+         process(Arrays.asList(new String[]{"0.3", "3", "1"}));
+         process(Arrays.asList(new String[]{"0.4", "4", "1"}));
+         process(Arrays.asList(new String[]{"0.5", "5", "1"}));
+         process(Arrays.asList(new String[]{"0.6", "6", "0"}));
+         process(Arrays.asList(new String[]{"0.7", "7", "2"}));
+         process(Arrays.asList(new String[]{"0.8", "8", "2"}));
+         process(Arrays.asList(new String[]{"0.9", "9", "2"}));
+         process(Arrays.asList(new String[]{"1.0", "10", "0"}));
+      }};
+      Map<String, String> actualMap = Blinks.analyze(data);
+      if (!actualMap.containsKey(KEY)) {
+         fail(String.format("Does not contain \"%s\"", KEY));
+      }
+      double actualBlinkRate = Double.parseDouble(actualMap.get(KEY));
+      assertEquals(EXPECTED_BLINK_RATE, actualBlinkRate, PRECISION);
+   }
+
+   @Test
+   public void testBlinksAnalyze_duplicateBlinkIdNonContinuousData() {
+      // 2 blinks in 0.5 second => (2/0.6)*60 = 200 blinks per minute
+      final double EXPECTED_BLINK_RATE = 200;
+      DataEntry data = new DataEntry(HEADERS) {{
+         process(Arrays.asList(new String[]{"0.0", "0", "0"}));
+         process(Arrays.asList(new String[]{"0.2", "2", "1"}));
+         process(Arrays.asList(new String[]{"0.3", "3", "1"}));
+         process(Arrays.asList(new String[]{"0.4", "4", "1"}));
+         process(Arrays.asList(new String[]{"0.5", "5", "1"}));
+         process(Arrays.asList(new String[]{"0.6", "6", "0"}));
+         process(Arrays.asList(new String[]{"0.7", "7", "2"}));
+         process(Arrays.asList(new String[]{"0.9", "9", "2"}));
+         process(Arrays.asList(new String[]{"1.0", "10", "0"}));
+      }};
+      Map<String, String> actualMap = Blinks.analyze(data);
+      if (!actualMap.containsKey(KEY)) {
+         fail(String.format("Does not contain \"%s\"", KEY));
+      }
+      double actualBlinkRate = Double.parseDouble(actualMap.get(KEY));
+      assertEquals(EXPECTED_BLINK_RATE, actualBlinkRate, PRECISION);
+   }
+}


### PR DESCRIPTION
fixes #37 
Blink rate is now calculated using the formula n/t, where n is the number of blinks and t is the time elapsed.

## Summary
- Time elapsed is determined by taking the timestamp of each data records (lines in all gaze file) and subtracting it from the previous timestamp of the previous data record.
- the code checks that the data records are consecutive using the **CNT** id. Only the time window between consecutive data records is added to the total time.
  - This approach was taken in order to support AOIs, where the participant's gaze will be entering and leaving. We want to exclude the time when the participant's gaze is outside the AOI when calculating AOI blink rates.
- The code counts the number of unique, non-zero blink ids (**BKID**) that occur in the data.

## Limitations to be aware of
- The raw, unfiltered gaze data must be used because the validity filtering process removes data records associated with blinks.
- For AOI blink rates, the **AOI** value is used from the raw gaze data. We post processed our gaze data to remove multi-AOI fixations from "fixation summary" records. The other data records have their original AOIs that may not align with their associated fixation summary record.
  - This limitation of the code exists for all DGMs that relies on the "all gaze" data, e.g., pupil dilation DGMs.
- For AOI blink rates, the sum of all AOI times is slightly less that the overall time. The time windows between consecutive data records that occur in different AOIs (including no AOI) are excluded in the AOI calculations. There is no way to determine the fraction of time the gaze was inside either AOI.
  - The eye tracker typically collects gaze data at a rate of 150 HZ, so 0.006 seconds is lost for every transition. At 150 Hz, the lost time is most likely negligible. If the 60 Hz setting is used, the AOI blink rates may become less accurate. 
- As t approaches zero, like in a rarely visited AOI, a single blink can greatly influence the blink rate. There will be AOI blink rates that are not humanly possible. 

## Testing
- Unit tests were added for different edge cases.
- I also ran the code using some gaze data from the ILS study.
  - I can compared the output beside the main branch to ensure that only the blink rate was modified.