### PR TITLE
Fixed entropy calculations and more

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up JDK 21
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: '21'
         distribution: 'temurin'

--- a/src/main/java/com/github/thed2lab/analysis/Angles.java
+++ b/src/main/java/com/github/thed2lab/analysis/Angles.java
@@ -1,12 +1,13 @@
 package com.github.thed2lab.analysis;
 
+import static com.github.thed2lab.analysis.Constants.FIXATION_ID;
+import static com.github.thed2lab.analysis.Constants.FIXATION_X;
+import static com.github.thed2lab.analysis.Constants.FIXATION_Y;
+
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 
 public class Angles {
-	final static String FIXATIONID_INDEX = "FPOGID";
-	final static String FIXATIONX_INDEX = "FPOGX";
-	final static String FIXATIONY_INDEX = "FPOGY";
 	
 	static public LinkedHashMap<String,String> analyze(DataEntry data) {
 		LinkedHashMap<String,String> results = new LinkedHashMap<String,String>();
@@ -14,9 +15,9 @@ public class Angles {
 
 		for (int row = 0; row < data.rowCount(); row++) {
 			Coordinate eachCoordinate = new Coordinate(
-				Double.valueOf(data.getValue(FIXATIONX_INDEX, row)),
-				Double.valueOf(data.getValue(FIXATIONY_INDEX, row)),
-				Integer.valueOf(data.getValue(FIXATIONID_INDEX, row))
+				Double.valueOf(data.getValue(FIXATION_X, row)),
+				Double.valueOf(data.getValue(FIXATION_Y, row)),
+				Integer.valueOf(data.getValue(FIXATION_ID, row))
 			);
 			allCoordinates.add(eachCoordinate);
 		}

--- a/src/main/java/com/github/thed2lab/analysis/AreaOfInterests.java
+++ b/src/main/java/com/github/thed2lab/analysis/AreaOfInterests.java
@@ -1,25 +1,27 @@
 package com.github.thed2lab.analysis;
 
-import java.util.Arrays;
+import static com.github.thed2lab.analysis.Constants.AOI_LABEL;
+import static com.github.thed2lab.analysis.Constants.FIXATION_DURATION;
+import static com.github.thed2lab.analysis.Constants.FIXATION_ID;
+import static com.github.thed2lab.analysis.Constants.SCREEN_HEIGHT;
+import static com.github.thed2lab.analysis.Constants.SCREEN_WIDTH;
+
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Set;
 
 public class AreaOfInterests {
-    final static String FIXATIONID_INDEX = "FPOGID"; //CNT
-    final static String DURATION_INDEX = "FPOGD";
-    final static String AOI_INDEX = "AOI";
-
 
     private static final String[] additionalHeaders = {"aoi", "proportion_of_fixations_spent_in_aoi","proportion_of_fixations_durations_spent_in_aoi"};
     private static final String[] perAoiHeaders = {"aoi_pair", "transition_count", "proportion_including_self_transitions", "proportion_excluding_self_transitions"};
     
     
-    public static void generateAOIs(DataEntry allGazeData, String outputDirectory, String fileName) {
+    public static void generateAOIs(DataEntry allGazeData, DataEntry fixationData, String outputDirectory, String fileName) {
         LinkedHashMap<String, DataEntry> aoiMetrics = new LinkedHashMap<>();
         for (int i = 0; i < allGazeData.rowCount(); i++) {
-            String aoi = allGazeData.getValue(AOI_INDEX, i);
+            String aoi = allGazeData.getValue(AOI_LABEL, i);
             String aoiKey = aoi.equals("") ? "Undefined Area" : aoi;
             if (!aoiMetrics.containsKey(aoiKey)) {
                 DataEntry d = new DataEntry(allGazeData.getHeaders());
@@ -28,18 +30,17 @@ public class AreaOfInterests {
             aoiMetrics.get(aoiKey).process(allGazeData.getRow(i));
         }
 
-        
+        DataEntry filteredFixations = DataFilter.filterByValidity(fixationData, SCREEN_WIDTH, SCREEN_HEIGHT);
         LinkedHashMap<String, DataEntry> aoiFixationMetrics = new LinkedHashMap<>();
-        DataEntry allFixations = DataFilter.filterByValidity(DataFilter.filterByFixations(allGazeData));
         //System.out.println(allFixations.rowCount());
-        for (int i = 0; i < allFixations.rowCount(); i++) {
-            String aoi = allFixations.getValue(AOI_INDEX, i);
+        for (int i = 0; i < filteredFixations.rowCount(); i++) {
+            String aoi = filteredFixations.getValue(AOI_LABEL, i);
             String aoiKey = aoi.equals("") ? "Undefined Area" : aoi;
             if (!aoiFixationMetrics.containsKey(aoiKey)) {
-                DataEntry d = new DataEntry(allFixations.getHeaders());
+                DataEntry d = new DataEntry(filteredFixations.getHeaders());
                 aoiFixationMetrics.put(aoiKey, d);
             }
-            aoiFixationMetrics.get(aoiKey).process(allFixations.getRow(i));
+            aoiFixationMetrics.get(aoiKey).process(filteredFixations.getRow(i));
         }
 
         // For any AOIs not in aoiFixationMetrics, add an empty DataEntry
@@ -59,7 +60,7 @@ public class AreaOfInterests {
         ArrayList<List<String>> metrics = new ArrayList<>();
         metrics.add(new ArrayList<String>());
         
-        double totalDuration = getDuration(allFixations);
+        double totalDuration = getDuration(filteredFixations);
         LinkedHashMap<String, DataEntry> validAOIs = new LinkedHashMap<>();
         boolean isFirst = true;
         Set<String> aoiKeySet = aoiMetrics.keySet();
@@ -80,11 +81,11 @@ public class AreaOfInterests {
             }
             results.get(1).add(aoiKey);
             metrics.add(results.get(1));
-            metrics.get(row).addAll(getProportions(allFixations, singleAoiFixations, totalDuration));
+            metrics.get(row).addAll(getProportions(filteredFixations, singleAoiFixations, totalDuration));
             validAOIs.put(aoiKey, singleAoiFixations);
             row++;
         }
-        ArrayList<List<String>> pairResults = generatePairResults(allFixations, aoiMetrics);
+        ArrayList<List<String>> pairResults = generatePairResults(filteredFixations, aoiMetrics);
         FileHandler.writeToCSV(metrics, outputDirectory, fileName + "_AOI_DGMs");
         FileHandler.writeToCSV(pairResults, outputDirectory, fileName+"_AOI_Transitions");
     }
@@ -102,7 +103,7 @@ public class AreaOfInterests {
     public static double getDuration(DataEntry fixations) {
         double durationSum = 0.0;
         for (int i = 0; i < fixations.rowCount(); i++) {
-            durationSum += Double.valueOf(fixations.getValue(DURATION_INDEX, i));
+            durationSum += Double.valueOf(fixations.getValue(FIXATION_DURATION, i));
         }
 
         return durationSum;
@@ -112,12 +113,12 @@ public class AreaOfInterests {
         LinkedHashMap<String, ArrayList<Integer>> totalTransitions = new LinkedHashMap<>(); // ArrayList<Integer>(Transtions, Inclusive, Exlusive);
         LinkedHashMap<String,LinkedHashMap<String, Integer>> transitionCounts = new LinkedHashMap<>();
         for (int i = 0; i < fixations.rowCount()-1; i++) {
-            String curAoi = fixations.getValue(AOI_INDEX, i);
+            String curAoi = fixations.getValue(AOI_LABEL, i);
             curAoi = curAoi.equals("") ? "Undefined Area" : curAoi;
-            int curId = Integer.valueOf(fixations.getValue(FIXATIONID_INDEX, i));
-            String nextAoi = fixations.getValue(AOI_INDEX, i+1);
+            int curId = Integer.valueOf(fixations.getValue(FIXATION_ID, i));
+            String nextAoi = fixations.getValue(AOI_LABEL, i+1);
             nextAoi = nextAoi.equals("") ? "Undefined Area" : nextAoi;
-            int nextId = Integer.valueOf(fixations.getValue(FIXATIONID_INDEX, i+1));
+            int nextId = Integer.valueOf(fixations.getValue(FIXATION_ID, i+1));
             boolean isValidAOI = (validAOIs.containsKey(curAoi) && validAOIs.containsKey(nextAoi));
             if (isValidAOI && nextId == curId + 1) { //Check if fixations are subsequent
                 if (!totalTransitions.containsKey(curAoi)) { //Ensure AOI is initialized in map.

--- a/src/main/java/com/github/thed2lab/analysis/AreaOfInterests.java
+++ b/src/main/java/com/github/thed2lab/analysis/AreaOfInterests.java
@@ -20,7 +20,7 @@ public class AreaOfInterests {
         LinkedHashMap<String, DataEntry> aoiMetrics = new LinkedHashMap<>();
         for (int i = 0; i < allGazeData.rowCount(); i++) {
             String aoi = allGazeData.getValue(AOI_INDEX, i);
-            String aoiKey = aoi.equals("") ? "No AOI" : aoi;
+            String aoiKey = aoi.equals("") ? "Undefined Area" : aoi;
             if (!aoiMetrics.containsKey(aoiKey)) {
                 DataEntry d = new DataEntry(allGazeData.getHeaders());
                 aoiMetrics.put(aoiKey, d);
@@ -34,7 +34,7 @@ public class AreaOfInterests {
         //System.out.println(allFixations.rowCount());
         for (int i = 0; i < allFixations.rowCount(); i++) {
             String aoi = allFixations.getValue(AOI_INDEX, i);
-            String aoiKey = aoi.equals("") ? "No AOI" : aoi;
+            String aoiKey = aoi.equals("") ? "Undefined Area" : aoi;
             if (!aoiFixationMetrics.containsKey(aoiKey)) {
                 DataEntry d = new DataEntry(allFixations.getHeaders());
                 aoiFixationMetrics.put(aoiKey, d);
@@ -113,10 +113,10 @@ public class AreaOfInterests {
         LinkedHashMap<String,LinkedHashMap<String, Integer>> transitionCounts = new LinkedHashMap<>();
         for (int i = 0; i < fixations.rowCount()-1; i++) {
             String curAoi = fixations.getValue(AOI_INDEX, i);
-            curAoi = curAoi.equals("") ? "No AOI" : curAoi;
+            curAoi = curAoi.equals("") ? "Undefined Area" : curAoi;
             int curId = Integer.valueOf(fixations.getValue(FIXATIONID_INDEX, i));
             String nextAoi = fixations.getValue(AOI_INDEX, i+1);
-            nextAoi = nextAoi.equals("") ? "No AOI" : nextAoi;
+            nextAoi = nextAoi.equals("") ? "Undefined Area" : nextAoi;
             int nextId = Integer.valueOf(fixations.getValue(FIXATIONID_INDEX, i+1));
             boolean isValidAOI = (validAOIs.containsKey(curAoi) && validAOIs.containsKey(nextAoi));
             if (isValidAOI && nextId == curId + 1) { //Check if fixations are subsequent

--- a/src/main/java/com/github/thed2lab/analysis/Blinks.java
+++ b/src/main/java/com/github/thed2lab/analysis/Blinks.java
@@ -1,13 +1,15 @@
 package com.github.thed2lab.analysis;
 
+import static com.github.thed2lab.analysis.Constants.BLINK_ID;
+import static com.github.thed2lab.analysis.Constants.DATA_ID;
+import static com.github.thed2lab.analysis.Constants.TIMESTAMP;
+
 import java.util.LinkedHashMap;
 
 public class Blinks {
    
-   final static String BLINK_ID_INDEX = "BKID";
-   final static String TIME_INDEX = "TIME";
-   final static String DATA_ID_INDEX = "CNT"; // unique for each line of raw data
-   final static String DEFAULT_BKID = "0"; // BKID when no blink is detected
+   /** Blink id when no blink is being detected. */
+   final static String DEFAULT_BKID = "0";
 
    static public LinkedHashMap<String,String> analyze(DataEntry allGazeData) {
 
@@ -18,14 +20,14 @@ public class Blinks {
       double prevTimestamp = 0;
       int prevDataId = -10; // IDs are always non-negative
       for (int i = 0; i < allGazeData.rowCount(); i++) {
-         int curDataId = Integer.parseInt(allGazeData.getValue(DATA_ID_INDEX, i));
-         double curTimestamp = Double.parseDouble(allGazeData.getValue(TIME_INDEX, i));
+         int curDataId = Integer.parseInt(allGazeData.getValue(DATA_ID, i));
+         double curTimestamp = Double.parseDouble(allGazeData.getValue(TIMESTAMP, i));
          // calculate time window between data records if they are consecutive
          if (curDataId == prevDataId + 1) {                    
             timeTotal += curTimestamp - prevTimestamp; 
          }
 
-         String curBlinkId = allGazeData.getValue(BLINK_ID_INDEX, i);
+         String curBlinkId = allGazeData.getValue(BLINK_ID, i);
          if (!curBlinkId.equals(DEFAULT_BKID) && !curBlinkId.equals(prevBlinkId)) {
             blinkCnt++; // new blink occurred
          }

--- a/src/main/java/com/github/thed2lab/analysis/Constants.java
+++ b/src/main/java/com/github/thed2lab/analysis/Constants.java
@@ -1,0 +1,64 @@
+package com.github.thed2lab.analysis;
+
+/**
+ * Hardcoded constants that are used throughout the package so there are fewer duplicated
+ * constants throughout the files.
+ */
+final class Constants {
+   /*
+    * Notice the access modifier is default (package-private).
+    * We could make this an injectable if we wanted to be better OO programmers, but I think
+    * this package is closely coupled enough that we don't care anymore.
+    */
+   
+   private Constants() {
+      // do not instantiate this class EVER!!!
+   }
+
+   /** Screen width in pixels */
+   final static int SCREEN_WIDTH = 1920;
+   /** Screen height in pixels */
+	final static int SCREEN_HEIGHT = 1080;
+
+   /** Header for timestamp of when the data line was recorded since the start of the recording in seconds */
+   final static String TIMESTAMP = "TIME";
+   /** Header for the unique ID given to each line of data */
+   final static String DATA_ID = "CNT";
+
+   /** Header for fixation ID. */
+   final static String FIXATION_ID = "FPOGID";
+   /** Header for the fixations starting timestamp */
+   final static String FIXATION_START = "FPOGS";
+   /** Header for fixation validity. 1 for true and 2 for false */
+   final static String FIXATION_VALIDITY = "FPOGV";
+   /** Header for the x-coordinate of the fixation point of gaze */
+   final static String FIXATION_X = "FPOGX";
+   /** Header for the y-coordinate of the fixation point of gaze */
+   final static String FIXATION_Y = "FPOGY";
+   /** Header for the duration of a fixation */
+   final static String FIXATION_DURATION = "FPOGD";
+
+   /** Header for the diameter of the left pupil in mm */
+   final static String LEFT_PUPIL_DIAMETER = "LPMM";
+   /** Header for the valid flag for the left pupil. A value of 1 is valid */
+   final static String LEFT_PUPIL_VALIDITY = "LPMMV";
+   /** Header for the diameter of the right pupil in mm */
+   final static String RIGHT_PUPIL_DIAMETER = "RPMM";
+   /** Header for the valid flag for the right pupil. A value of 1 is valid */
+   final static String RIGHT_PUPIL_VALIDITY = "RPMMV";
+
+   /** Header for cursor events */
+   final static String CURSOR_EVENT = "CS";
+   /** Header for the blink ID */
+   final static String BLINK_ID = "BKID";
+   /** Header for the blink rate per minute */
+   final static String BLINK_RATE = "BKPMIN";
+   /** Header for the AOI Label */
+   final static String AOI_LABEL = "AOI";
+
+   /** Header for the saccade magnitude */
+   final static String SACCADE_MAGNITUDE = "SACCADE_MAG";
+   /** Header for the saccade direction */
+   final static String SACCADE_DIR = "SACCADE_DIR";
+
+}

--- a/src/main/java/com/github/thed2lab/analysis/ConvexHull.java
+++ b/src/main/java/com/github/thed2lab/analysis/ConvexHull.java
@@ -1,5 +1,8 @@
 package com.github.thed2lab.analysis;
 
+import static com.github.thed2lab.analysis.Constants.FIXATION_X;
+import static com.github.thed2lab.analysis.Constants.FIXATION_Y;
+
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
@@ -11,16 +14,14 @@ import java.awt.geom.Point2D;
 import java.awt.Point;
 
 public class ConvexHull {
-    final static String FIXATIONX_INDEX = "FPOGX";
-    final static String FIXATIONY_INDEX = "FPOGY";
     
     static public LinkedHashMap<String,String> analyze(DataEntry data) {
         LinkedHashMap<String,String> results = new LinkedHashMap<String,String>();
         List<Point2D.Double> allPoints = new ArrayList<>();
 
         for (int row = 0; row < data.rowCount(); row++) {
-            double x = Double.valueOf(data.getValue(FIXATIONX_INDEX, row));
-            double y = Double.valueOf(data.getValue(FIXATIONY_INDEX, row));
+            double x = Double.valueOf(data.getValue(FIXATION_X, row));
+            double y = Double.valueOf(data.getValue(FIXATION_Y, row));
             allPoints.add(new Point2D.Double(x, y));
         }  
         List<Point2D.Double> boundingPoints = getConvexHull(allPoints);

--- a/src/main/java/com/github/thed2lab/analysis/DataFilter.java
+++ b/src/main/java/com/github/thed2lab/analysis/DataFilter.java
@@ -1,7 +1,15 @@
 package com.github.thed2lab.analysis;
 
+import static com.github.thed2lab.analysis.Constants.FIXATION_ID;
+import static com.github.thed2lab.analysis.Constants.FIXATION_VALIDITY;
+import static com.github.thed2lab.analysis.Constants.FIXATION_X;
+import static com.github.thed2lab.analysis.Constants.FIXATION_Y;
+import static com.github.thed2lab.analysis.Constants.LEFT_PUPIL_DIAMETER;
+import static com.github.thed2lab.analysis.Constants.LEFT_PUPIL_VALIDITY;
+import static com.github.thed2lab.analysis.Constants.RIGHT_PUPIL_DIAMETER;
+import static com.github.thed2lab.analysis.Constants.RIGHT_PUPIL_VALIDITY;
+
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 
 // Note: Order used for data filtering matters and can invalidate DataEntrys if used incorrectly
@@ -14,8 +22,8 @@ public class DataFilter {
         int currFixation = 1;
 
         for (int row = 0; row < data.rowCount(); row++) {
-            int fixationID = Integer.parseInt(data.getValue("FPOGID", row));
-            int fixationValidity = Integer.parseInt(data.getValue("FPOGV", row));
+            int fixationID = Integer.parseInt(data.getValue(FIXATION_ID, row));
+            int fixationValidity = Integer.parseInt(data.getValue(FIXATION_VALIDITY, row));
             if (fixationID != currFixation) {
                 if (lastValidFixation != null) filtered.process(lastValidFixation);
                 if (fixationValidity == 1) lastValidFixation = data.getRow(row); // Edge case; check to see if the first line associated with a given fixation is valid
@@ -35,37 +43,51 @@ public class DataFilter {
     /**
      * Cleanses data by filtering out invalid data. Valid data entries must occur within
      * the bounds of the monitor and have humanly possible pupil dilation.
-     * @param data Data to be cleansed
+     * @param data data to be cleansed.
      */
     public static DataEntry filterByValidity(DataEntry data) {
+        // GazePoint scales point of gaze location from 0 to 1 when on screen
+        final int MAX_SCREEN_WIDTH = 1;
+        final int MAX_SCREEN_HEIGHT = 1;
+        return filterByValidity(data, MAX_SCREEN_WIDTH, MAX_SCREEN_HEIGHT);
+    }
+
+    /**
+     * Cleanses data by filtering out invalid data. Valid data entries must occur within
+     * the bounds of the monitor and have humanly possible pupil dilation.
+     * @param data data to be cleansed.
+     * @param screenWidth screen width scaler that was previously applied to the data.
+     * @param screenHeight screen height scaler that was previously applied to the data.
+     */
+    public static DataEntry filterByValidity(DataEntry data, int screenWidth, int screenHeight) {
         // humanly possible pupil diameter is between 2 and 8 mm
         final int MIN_DIAMETER = 2;
         final int MAX_DIAMETER = 8;
         final int MAX_PUPIL_DIFF = 1;   
-        // GazePoint scales point of gaze location from 0 to 1 when on screen
-        final int MIN_SCREEN_DIM = 0;   
-        final int MAX_SCREEN_DIM = 1;   
+        // GazePoint scales point of gaze location from 0 to 1 when on screen. The data
+        // may have been scaled so we only hardcode the 0
+        final int MIN_SCREEN_DIM = 0;
 
         DataEntry filtered = new DataEntry(data.getHeaders());
         for (int rowNum = 0; rowNum < data.rowCount(); rowNum++) {
             // Note: It is extremely slow to parse a string over and over again
             // Check if Gazepoint could detect the pupils
-            boolean leftValid = Integer.parseInt(data.getValue("LPMMV", rowNum)) == 1;
-            boolean rightValid = Integer.parseInt(data.getValue("RPMMV", rowNum)) == 1;
+            boolean leftValid = Integer.parseInt(data.getValue(LEFT_PUPIL_VALIDITY, rowNum)) == 1;
+            boolean rightValid = Integer.parseInt(data.getValue(RIGHT_PUPIL_VALIDITY, rowNum)) == 1;
             if (!(leftValid && rightValid)) {
                 continue;   // skip invalid entry
             } 
             // Check if POG is on the screen
-            float xCoordinate = Float.parseFloat(data.getValue("FPOGX" ,rowNum));
-            float yCoordinate = Float.parseFloat(data.getValue("FPOGY" ,rowNum));
-            if (xCoordinate < MIN_SCREEN_DIM || xCoordinate > MAX_SCREEN_DIM) {
+            float xCoordinate = Float.parseFloat(data.getValue(FIXATION_X ,rowNum));
+            float yCoordinate = Float.parseFloat(data.getValue(FIXATION_Y ,rowNum));
+            if (xCoordinate < MIN_SCREEN_DIM || xCoordinate > screenWidth) {
                 continue; // off screen in x-direction, invalid
-            } else if (yCoordinate < MIN_SCREEN_DIM || yCoordinate > MAX_SCREEN_DIM) {
+            } else if (yCoordinate < MIN_SCREEN_DIM || yCoordinate > screenHeight) {
                 continue; // off screen in y-direction, invalid entry
             }
             // Check if pupils are valid sizes individually and compared to each other.
-            float leftDiameter = Float.parseFloat(data.getValue("LPMM", rowNum));
-            float rightDiameter = Float.parseFloat(data.getValue("RPMM", rowNum));
+            float leftDiameter = Float.parseFloat(data.getValue(LEFT_PUPIL_DIAMETER, rowNum));
+            float rightDiameter = Float.parseFloat(data.getValue(RIGHT_PUPIL_DIAMETER, rowNum));
             if (
                 leftDiameter >= MIN_DIAMETER
                 && leftDiameter <= MAX_DIAMETER
@@ -87,8 +109,8 @@ public class DataFilter {
             List<String> newRow = new ArrayList<String>();
             newRow.addAll(currentRow);
 
-            int fixationXIndex = data.getHeaderIndex("FPOGX");
-            int fixationYIndex = data.getHeaderIndex("FPOGY");
+            int fixationXIndex = data.getHeaderIndex(FIXATION_X);
+            int fixationYIndex = data.getHeaderIndex(FIXATION_Y);
 
             newRow.set(fixationXIndex,String.valueOf(Double.valueOf(newRow.get(fixationXIndex)) * screenWidth));
             newRow.set(fixationYIndex,String.valueOf(Double.valueOf(newRow.get(fixationYIndex)) * screenHeight));
@@ -97,11 +119,5 @@ public class DataFilter {
         }
 
         return filtered;
-    }
-
-
-    static public LinkedHashMap<String, DataEntry> filterByAOI(DataEntry data ){
-        
-        return new LinkedHashMap<String, DataEntry>();
     }
 }

--- a/src/main/java/com/github/thed2lab/analysis/Event.java
+++ b/src/main/java/com/github/thed2lab/analysis/Event.java
@@ -1,16 +1,17 @@
 package com.github.thed2lab.analysis;
 
+import static com.github.thed2lab.analysis.Constants.CURSOR_EVENT;
+
 import java.util.LinkedHashMap;
 
 public class Event {
-    final static String INPUT_INDEX = "CS";
     
     static public LinkedHashMap<String,String> analyze(DataEntry data) {
         LinkedHashMap<String,String> results = new LinkedHashMap<String,String>();
         int leftMouseClicks = 0;
 
         for (int row = 0; row < data.rowCount(); row++) {
-            if (data.getValue(INPUT_INDEX, row).equals("1")) {
+            if (data.getValue(CURSOR_EVENT, row).equals("1")) {
                 leftMouseClicks += 1;
             }
         }

--- a/src/main/java/com/github/thed2lab/analysis/Fixations.java
+++ b/src/main/java/com/github/thed2lab/analysis/Fixations.java
@@ -1,10 +1,11 @@
 package com.github.thed2lab.analysis;
 
+import static com.github.thed2lab.analysis.Constants.FIXATION_DURATION;
+
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 
 public class Fixations {
-    final static String DURATION_INDEX = "FPOGD";
 
     static public LinkedHashMap<String,String> analyze(DataEntry data) {
         LinkedHashMap<String,String> results = new LinkedHashMap<String,String>();
@@ -13,7 +14,7 @@ public class Fixations {
         int fixationCount = data.rowCount();
         
         for (int row = 0; row < data.rowCount(); row++) {    
-            Double fixationDurationSeconds = Double.valueOf(data.getValue(DURATION_INDEX, row));
+            Double fixationDurationSeconds = Double.valueOf(data.getValue(FIXATION_DURATION, row));
             allFixationDurations.add(fixationDurationSeconds);
         }
         

--- a/src/main/java/com/github/thed2lab/analysis/Gaze.java
+++ b/src/main/java/com/github/thed2lab/analysis/Gaze.java
@@ -1,10 +1,10 @@
 package com.github.thed2lab.analysis;
 
+import static com.github.thed2lab.analysis.Constants.*;
+
 import java.util.LinkedHashMap;
 
 public class Gaze {
-    final static String PUPIL_LEFT_DIAMETER_INDEX = "LPMM";
-    final static String PUPIL_RIGHT_DIAMETER_INDEX = "RPMM";
 
     static public LinkedHashMap<String,String> analyze(DataEntry data) {
         LinkedHashMap<String,String> results = new LinkedHashMap<String,String>();
@@ -14,8 +14,8 @@ public class Gaze {
         int count = data.rowCount();
 
         for (int row = 0; row < data.rowCount(); row++) {
-            double leftSize = Double.valueOf(data.getValue(PUPIL_LEFT_DIAMETER_INDEX, row));
-            double rightSize = Double.valueOf(data.getValue(PUPIL_RIGHT_DIAMETER_INDEX, row));
+            double leftSize = Double.valueOf(data.getValue(LEFT_PUPIL_DIAMETER, row));
+            double rightSize = Double.valueOf(data.getValue(RIGHT_PUPIL_DIAMETER, row));
             leftSum += leftSize;
             rightSum += rightSize;
             bothSum += (leftSize + rightSize) / 2.0;

--- a/src/main/java/com/github/thed2lab/analysis/GazeEntropy.java
+++ b/src/main/java/com/github/thed2lab/analysis/GazeEntropy.java
@@ -9,32 +9,31 @@ public class GazeEntropy {
     private final static String AOI_INDEX = "AOI";
 
     /**
-     * Iterates over all rows of a participant’s fixations and calculates the probability of transition to each AOI, as well as calculating
-     * the probability that, given a fixation is in some AOI<sub>A</sub>, the probability of transitioning to some AOI<sub>B</sub>.
-     * @param fixations the users gaze data, filtered by fixations and validity with screen size applied
-     * @return a map with the key as the outputted variable’s name and the value as a string containing the result
+     * Calculates the stationary entropy and transition entropy measures. The method iterates over the participant’s
+     * fixations, determining the probability of viewing each AOI and the probability of transitioning from one AOI
+     * to another. All lines of data not labeled with an AOI are treated as if they appear in a single AOI.
+     * Therefore, n in the entropy formula will be the total number of labeled AOIs plus one. .
+     * @param fixations the users gaze data, filtered by fixations and validity with screen size applied.
+     * @return an ordered map containing the stationary and transition entropy headers as keys mapped to their computed values.
      */
     static public LinkedHashMap<String,String> analyze(DataEntry fixations) {
         var aoiProbability = new HashMap<String, Double>();
         var transitionProbability = new HashMap<String, Map<String, Double>>();
         var aoiSequence = new ArrayList<String>();
-        String lastAoi = "";
+        String lastAoi = null;
         
         int fixationCount = fixations.rowCount();
         
         for (int row = 0; row < fixations.rowCount(); row++) {
             String aoi = fixations.getValue(AOI_INDEX, row);
             aoiSequence.add(aoi);
-            
-            if (aoi.equals(""))
-                continue;
             aoiProbability.put(aoi, aoiProbability.getOrDefault(aoi, 0.0) + 1);
-            if (!lastAoi.equals("")) {
+            if (lastAoi != null) {  // skips the first loop
                 Map<String, Double> relationMatrix = transitionProbability.getOrDefault(lastAoi, new HashMap<String,Double>());
                 double count = relationMatrix.getOrDefault(aoi, 0.0);
                 relationMatrix.put(aoi, count + 1);
                 transitionProbability.put(lastAoi, relationMatrix);
-            }  
+            }
             lastAoi = aoi;
         }
 
@@ -71,9 +70,9 @@ public class GazeEntropy {
     }
 
     /**
-     * Calculates the stationary entropy score
-     * @param aoiProbability a map between an AOI name and probability that any given transition is to that AOI
-     * @return the stationary entropy score
+     * Calculates the stationary entropy score.
+     * @param aoiProbability the AOI labels mapped to the probability of viewing the AOI.
+     * @return the stationary entropy score.
      */
     static double getStationaryEntropy(Map<String, Double> aoiProbability) {
 		double stationaryEntropy = 0;
@@ -87,10 +86,11 @@ public class GazeEntropy {
 	
     /**
      * Calculates the transition entropy score.
-     * @param aoiProbability the AOI name mapped to the probability that a transition is to that AOI
-     * @param transitionMatrix the outer matrix has a key for each AOI (A). The value for each AOI is another Hashmap containing all AOIs (inclusive) (B).
-     * The value for each of those is the probability of transitioning from A to B.
-     * @return the stationary entropy score
+     * @param aoiProbability the AOI labels mapped to the probability of viewing the AOI.
+     * @param transitionMatrix the outer map has a key for each AOI (A). The value for each AOI is another map
+     * containing all AOIs (inclusive) (B). The value for each of those is the probability of transitioning
+     * from A to B.
+     * @return the stationary entropy score.
      */
 	static double getTransitionEntropy(Map<String, Double> aoiProbability, Map<String, Map<String,Double>> transitionMatrix){	
     	double transitionEntropy = 0;

--- a/src/main/java/com/github/thed2lab/analysis/GazeEntropy.java
+++ b/src/main/java/com/github/thed2lab/analysis/GazeEntropy.java
@@ -6,40 +6,35 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class GazeEntropy {
-    final static String AOI_INDEX = "AOI";
+    private final static String AOI_INDEX = "AOI";
 
-    static public LinkedHashMap<String,String> analyze(DataEntry data) {
-        LinkedHashMap<String,String> results = new LinkedHashMap<String,String>();
-
-        HashMap<String, Double> aoiProbability = new HashMap<String, Double>();
-        HashMap<String, HashMap<String, Double>> transitionProbability = new HashMap<String, HashMap<String, Double>>();
-        ArrayList<String> aoiSequence = new ArrayList<String>();
+    /**
+     * Iterates over all rows of a participant’s fixations and calculates the probability of transition to each AOI, as well as calculating
+     * the probability that, given a fixation is in some AOI<sub>A</sub>, the probability of transitioning to some AOI<sub>B</sub>.
+     * @param fixations the users gaze data, filtered by fixations and validity with screen size applied
+     * @return a map with the key as the outputted variable’s name and the value as a string containing the result
+     */
+    static public LinkedHashMap<String,String> analyze(DataEntry fixations) {
+        var aoiProbability = new HashMap<String, Double>();
+        var transitionProbability = new HashMap<String, Map<String, Double>>();
+        var aoiSequence = new ArrayList<String>();
         String lastAoi = "";
         
-        int fixationCount = data.rowCount();
+        int fixationCount = fixations.rowCount();
         
-        for (int row = 0; row < data.rowCount(); row++) {
-            String aoi = data.getValue(AOI_INDEX, row);
+        for (int row = 0; row < fixations.rowCount(); row++) {
+            String aoi = fixations.getValue(AOI_INDEX, row);
             aoiSequence.add(aoi);
             
             if (aoi.equals(""))
                 continue;
-            else if (aoiProbability.containsKey(aoi)) {
-                aoiProbability.put(aoi, aoiProbability.get(aoi) + 1);
-                if (!lastAoi.equals("")) {
-                    HashMap<String, Double> relationMatrix = transitionProbability.get(lastAoi);
-                    if (relationMatrix.containsKey(aoi)) {
-                        double count = relationMatrix.get(aoi);
-                        relationMatrix.put(aoi, count + 1);
-                    } else {
-                        relationMatrix.put(aoi, 1.0);
-                    }
-                }
-                
-            } else {
-                aoiProbability.put(aoi, 1.0);
-                transitionProbability.put(aoi, new HashMap<String,Double>());
-            }
+            aoiProbability.put(aoi, aoiProbability.getOrDefault(aoi, 0.0) + 1);
+            if (!lastAoi.equals("")) {
+                Map<String, Double> relationMatrix = transitionProbability.getOrDefault(lastAoi, new HashMap<String,Double>());
+                double count = relationMatrix.getOrDefault(aoi, 0.0);
+                relationMatrix.put(aoi, count + 1);
+                transitionProbability.put(lastAoi, relationMatrix);
+            }  
             lastAoi = aoi;
         }
 
@@ -50,7 +45,7 @@ public class GazeEntropy {
         }
         
         
-        for (Map.Entry<String, HashMap<String, Double>> entry : transitionProbability.entrySet()) {
+        for (Map.Entry<String, Map<String, Double>> entry : transitionProbability.entrySet()) {
             int aoiTransitions = 0;
             for (Map.Entry<String, Double> edge : entry.getValue().entrySet()) {
                 aoiTransitions += edge.getValue();
@@ -59,6 +54,8 @@ public class GazeEntropy {
                 edge.setValue(edge.getValue()/aoiTransitions);
             }
         }
+
+        var results = new LinkedHashMap<String,String>();
 
         results.put(
             "stationary_entropy", //Output Header
@@ -73,7 +70,12 @@ public class GazeEntropy {
         return results;
     }
 
-    public static double getStationaryEntropy(HashMap<String, Double> aoiProbability) {
+    /**
+     * Calculates the stationary entropy score
+     * @param aoiProbability a map between an AOI name and probability that any given transition is to that AOI
+     * @return the stationary entropy score
+     */
+    static double getStationaryEntropy(Map<String, Double> aoiProbability) {
 		double stationaryEntropy = 0;
 		for (Map.Entry<String, Double> entry : aoiProbability.entrySet()) {
 			double probability = entry.getValue();
@@ -83,9 +85,16 @@ public class GazeEntropy {
 		return stationaryEntropy;
 	}
 	
-	public static double getTransitionEntropy(HashMap<String, Double> aoiProbability, HashMap<String,HashMap<String,Double>> transitionMatrix){	
+    /**
+     * Calculates the transition entropy score.
+     * @param aoiProbability the AOI name mapped to the probability that a transition is to that AOI
+     * @param transitionMatrix the outer matrix has a key for each AOI (A). The value for each AOI is another Hashmap containing all AOIs (inclusive) (B).
+     * The value for each of those is the probability of transitioning from A to B.
+     * @return the stationary entropy score
+     */
+	static double getTransitionEntropy(Map<String, Double> aoiProbability, Map<String, Map<String,Double>> transitionMatrix){	
     	double transitionEntropy = 0;
-		for (Map.Entry<String,HashMap<String,Double>> entry : transitionMatrix.entrySet()) {
+		for (Map.Entry<String,Map<String,Double>> entry : transitionMatrix.entrySet()) {
     		double pijSum = 0;
     		for (Map.Entry<String, Double> edge : entry.getValue().entrySet()) {
     			pijSum += edge.getValue() * Math.log10(edge.getValue());

--- a/src/main/java/com/github/thed2lab/analysis/GazeEntropy.java
+++ b/src/main/java/com/github/thed2lab/analysis/GazeEntropy.java
@@ -1,12 +1,13 @@
 package com.github.thed2lab.analysis;
 
+import static com.github.thed2lab.analysis.Constants.AOI_LABEL;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class GazeEntropy {
-    private final static String AOI_INDEX = "AOI";
 
     /**
      * Calculates the stationary entropy and transition entropy measures. The method iterates over the participant’s
@@ -25,7 +26,7 @@ public class GazeEntropy {
         int fixationCount = fixations.rowCount();
         
         for (int row = 0; row < fixations.rowCount(); row++) {
-            String aoi = fixations.getValue(AOI_INDEX, row);
+            String aoi = fixations.getValue(AOI_LABEL, row);
             aoiSequence.add(aoi);
             aoiProbability.put(aoi, aoiProbability.getOrDefault(aoi, 0.0) + 1);
             if (lastAoi != null) {  // skips the first loop

--- a/src/main/java/com/github/thed2lab/analysis/Parameters.java
+++ b/src/main/java/com/github/thed2lab/analysis/Parameters.java
@@ -47,19 +47,6 @@ public class Parameters {
         return "--Parameters-- \n InputFiles: ["+inputFiles.length+"] "+Arrays.toString(inputFiles)+" \n OutputDirectory: "+outputDirectory +"\n --End of Parameters--";
     }
 
-    /* public static void main(String[] args) {
-        System.out.println("Creating and saving Parameters!");
-
-    //     Parameters p = new Parameters(new String[]{"data\\Kayla_all_gaze.csv","data\\Esther Jung_all_gaze.csv"},"data\\presets", new HashMap<>());
-    //     p.saveToJSON("data\\presets","TestConfig.json");
-
-    //     System.out.println(p.toString());
-    //     System.out.println("Loading parameters!");
-
-        Parameters p2 = new Parameters(new File("data\\presets\\TestConfig.json"));
-        System.out.println(p2.toString());
-    } */
-
     public File[] getInputFiles() {
         return this.inputFiles.clone();
     }

--- a/src/main/java/com/github/thed2lab/analysis/Patterns.java
+++ b/src/main/java/com/github/thed2lab/analysis/Patterns.java
@@ -34,12 +34,6 @@ public class Patterns {
                 double averagePatternFrequency = (double) frequencyMap.get(pattern)/sequences.size();
                 double proportionalPatternFrequency = (double) frequencyMap.get(pattern)/totalPatternCount;
                 
-                // System.out.print(pattern + " ");
-                // System.out.print(frequency + " ");
-                // System.out.print(sequenceSupport + " ");
-                // System.out.print(averagePatternFrequency + " ");
-                // System.out.println(proportionalPatternFrequency + " ");
-                
                 if (frequency >= minFrequency && sequenceMap.get(pattern).size() >= minSequenceSize) {
                     List<String> patternData = new ArrayList<String>();
                     patternData.add(pattern);

--- a/src/main/java/com/github/thed2lab/analysis/SaccadeVelocity.java
+++ b/src/main/java/com/github/thed2lab/analysis/SaccadeVelocity.java
@@ -1,24 +1,24 @@
 package com.github.thed2lab.analysis;
 
+import static com.github.thed2lab.analysis.Constants.FIXATION_ID;
+import static com.github.thed2lab.analysis.Constants.FIXATION_VALIDITY;
+import static com.github.thed2lab.analysis.Constants.FIXATION_X;
+import static com.github.thed2lab.analysis.Constants.FIXATION_Y;
+import static com.github.thed2lab.analysis.Constants.TIMESTAMP;
+
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 
 public class SaccadeVelocity {
-    final static String TIME_INDEX = "TIME";
-    final static String FIXATIONID_INDEX = "FPOGID";
-    final static String FIXATIONX_INDEX = "FPOGX";
-    final static String FIXATIONY_INDEX = "FPOGY";
-    final static String FIXATION_VALIDITY_INDEX = "FPOGV";
-    final static String FIXATION_DURATION_INDEX = "FPOGD";
 
     /**
      * Calculates the average peak saccade velocity. Iterates over all rows of a participant’s gaze.
      * If the current row’s fixation ID (“FID”) and the next consecutive fixation ID both appear in
      * the fixation data as well as if the fixation validity (“FPOGV”) is set to 0, then the row is
      * considered part of a saccade.
-     * @param allGazeData all gaze data, filtered by validity with screen size applied. When calculating
-     * for AOIs, use all gaze data, not just the AOI specific gaze data.
+     * @param allGazeData all gaze data, with screen size applied. When calculating for AOIs, use all
+     * gaze data, not just the AOI specific gaze data.
      * @param fixationData the gaze data, filtered by fixation and validity with screen size applied.
      * When calculating for AOIs, use only fixation data that occurs within the AOI.
      * @return average peak saccade velocity’s header mapped to the calculated value as a {@code String}.
@@ -36,8 +36,8 @@ public class SaccadeVelocity {
         while ((fixDataIndex < fixationData.rowCount() - 1) && (gazeDataIndex < allGazeData.rowCount())) {
             // Get the fixation Id of the next saccade that occurs completely within portion of screen (whole or AOI)
             while (fixDataIndex < fixationData.rowCount() - 1) {
-                int curFixId = Integer.parseInt(fixationData.getValue(FIXATIONID_INDEX, fixDataIndex));
-                int nextFixId = Integer.parseInt(fixationData.getValue(FIXATIONID_INDEX, fixDataIndex + 1));
+                int curFixId = Integer.parseInt(fixationData.getValue(FIXATION_ID, fixDataIndex));
+                int nextFixId = Integer.parseInt(fixationData.getValue(FIXATION_ID, fixDataIndex + 1));
                 fixDataIndex++;
                 if (nextFixId == curFixId + 1) {
                     targetFixId = curFixId;
@@ -46,7 +46,7 @@ public class SaccadeVelocity {
             }
 
             while (gazeDataIndex < allGazeData.rowCount()) {
-                int curId = Integer.parseInt(allGazeData.getValue(FIXATIONID_INDEX, gazeDataIndex));
+                int curId = Integer.parseInt(allGazeData.getValue(FIXATION_ID, gazeDataIndex));
                 if (curId < targetFixId) {
                     gazeDataIndex++;
                     continue;
@@ -54,16 +54,16 @@ public class SaccadeVelocity {
                     break; // could not find target, look for next fixation
                 }
 
-                boolean saccade = Integer.parseInt(allGazeData.getValue(FIXATION_VALIDITY_INDEX, gazeDataIndex)) == 0 ? true : false;
+                boolean saccade = Integer.parseInt(allGazeData.getValue(FIXATION_VALIDITY, gazeDataIndex)) == 0 ? true : false;
                 // Check if not a saccade
                 if (!saccade) {
                     gazeDataIndex++;
                     continue; // go to next data point
                 }
 
-                Double x = Double.parseDouble(allGazeData.getValue(FIXATIONX_INDEX, gazeDataIndex));
-                Double y = Double.parseDouble(allGazeData.getValue(FIXATIONY_INDEX, gazeDataIndex));
-                Double t = Double.parseDouble(allGazeData.getValue(TIME_INDEX, gazeDataIndex));
+                Double x = Double.parseDouble(allGazeData.getValue(FIXATION_X, gazeDataIndex));
+                Double y = Double.parseDouble(allGazeData.getValue(FIXATION_Y, gazeDataIndex));
+                Double t = Double.parseDouble(allGazeData.getValue(TIMESTAMP, gazeDataIndex));
                 positionProfile.add(new Double[] {x, y, t});
                 gazeDataIndex++;
             }

--- a/src/main/java/com/github/thed2lab/analysis/Saccades.java
+++ b/src/main/java/com/github/thed2lab/analysis/Saccades.java
@@ -1,14 +1,15 @@
 package com.github.thed2lab.analysis;
 
+import static com.github.thed2lab.analysis.Constants.FIXATION_DURATION;
+import static com.github.thed2lab.analysis.Constants.FIXATION_ID;
+import static com.github.thed2lab.analysis.Constants.FIXATION_X;
+import static com.github.thed2lab.analysis.Constants.FIXATION_Y;
+import static com.github.thed2lab.analysis.Constants.FIXATION_START;
+
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 
 public class Saccades {
-    final static String DURATION_INDEX = "FPOGD";
-    final static String TIMESTAMP_INDEX = "FPOGS";
-    final static String FIXATIONID_INDEX = "FPOGID";
-    final static String FIXATIONX_INDEX = "FPOGX";
-    final static String FIXATIONY_INDEX = "FPOGY";
     
     static public LinkedHashMap<String,String> analyze(DataEntry data) {
         LinkedHashMap<String,String> results = new LinkedHashMap<String,String>();
@@ -18,18 +19,18 @@ public class Saccades {
         ArrayList<Coordinate> allCoordinates = new ArrayList<>();
         
         for (int row = 0; row < data.rowCount(); row++) {
-            Double fixationDurationSeconds = Double.valueOf(data.getValue(DURATION_INDEX, row));;
+            Double fixationDurationSeconds = Double.valueOf(data.getValue(FIXATION_DURATION, row));;
 
             Double[] eachSaccadeDetail = new Double[3];
-            eachSaccadeDetail[0] = Double.valueOf(data.getValue(TIMESTAMP_INDEX, row));
-            eachSaccadeDetail[1] = Double.valueOf(data.getValue(DURATION_INDEX, row));
-            eachSaccadeDetail[2] = Double.valueOf(data.getValue(FIXATIONID_INDEX, row));
+            eachSaccadeDetail[0] = Double.valueOf(data.getValue(FIXATION_START, row));
+            eachSaccadeDetail[1] = Double.valueOf(data.getValue(FIXATION_DURATION, row));
+            eachSaccadeDetail[2] = Double.valueOf(data.getValue(FIXATION_ID, row));
             saccadeDetails.add(eachSaccadeDetail);
 
             Coordinate eachCoordinate = new Coordinate(
-                Double.valueOf(data.getValue(FIXATIONX_INDEX, row)),
-                Double.valueOf(data.getValue(FIXATIONY_INDEX, row)),
-                Integer.valueOf(data.getValue(FIXATIONID_INDEX, row))
+                Double.valueOf(data.getValue(FIXATION_X, row)),
+                Double.valueOf(data.getValue(FIXATION_Y, row)),
+                Integer.valueOf(data.getValue(FIXATION_ID, row))
             );
             allCoordinates.add(eachCoordinate);
             allFixationDurations.add(fixationDurationSeconds);

--- a/src/main/java/com/github/thed2lab/analysis/Sequences.java
+++ b/src/main/java/com/github/thed2lab/analysis/Sequences.java
@@ -15,7 +15,7 @@ public class Sequences {
         // Build aoiDescriptions string 
         for (String s: map.keySet()) {
             int asciiValue = map.get(s);
-            String description = s == "" ? "No AOI" : s;
+            String description = s == "" ? "Undefined Area" : s;
             aoiDescriptions += (char)asciiValue + ", " + description + "\n";
         }
 
@@ -26,7 +26,7 @@ public class Sequences {
             if (!map.containsKey(aoi)) {
                 map.put(aoi, map.size() + ascii);
 
-                String description = aoi == "" ? "No AOI" : aoi;
+                String description = aoi == "" ? "Undefined Area" : aoi;
                 aoiDescriptions += (char)(map.size() + ascii - 1) + ", " +  description  + "\n";
             }
             

--- a/src/main/java/com/github/thed2lab/analysis/Sequences.java
+++ b/src/main/java/com/github/thed2lab/analysis/Sequences.java
@@ -1,11 +1,11 @@
 package com.github.thed2lab.analysis;
 
+import static com.github.thed2lab.analysis.Constants.AOI_LABEL;
+
 import java.util.HashMap;
 import java.util.List;
 
 public class Sequences {
-    
-    final static String AOI_INDEX = "AOI";
 
     public static void generateSequenceFiles(DataEntry data, String outputDirectory, List<String> sequences, HashMap<String, Integer> map) {
         String aoiDescriptions = "";
@@ -21,7 +21,7 @@ public class Sequences {
 
         // Generate sequence
         for (int i = 0; i < data.rowCount(); i++) {
-            String aoi = data.getValue(AOI_INDEX, i);
+            String aoi = data.getValue(AOI_LABEL, i);
 
             if (!map.containsKey(aoi)) {
                 map.put(aoi, map.size() + ascii);

--- a/src/test/java/com/github/thed2lab/analysis/GazeEntropyTest.java
+++ b/src/test/java/com/github/thed2lab/analysis/GazeEntropyTest.java
@@ -12,11 +12,34 @@ public class GazeEntropyTest {
    private final String STATIONARY_ENTROPY = "stationary_entropy";
    private final String TRANSITION_ENTROPY = "transition_entropy";
 
-   
    @Test
-   public void testAnalyze_twoAoi() {
-      final double EXPECTED_STATIONARY = 0.301029995663981;
-      final double EXPECTED_TRANSITION = 0.288732293303828;
+   public void testGazeEntropyAnalyze_singleAoi_0entropy() {
+      final double EXPECTED_STATIONARY = 0.0;
+      final double EXPECTED_TRANSITION = 0.0;
+      DataEntry data = new DataEntry(Arrays.asList("AOI")) {{
+         process(Arrays.asList("A"));
+         process(Arrays.asList("A"));
+         process(Arrays.asList("A"));
+         process(Arrays.asList("A"));
+      }};
+      var results = GazeEntropy.analyze(data);
+      assertEquals(
+         "Unexpected stationary entropy.",
+         EXPECTED_STATIONARY,
+         Double.parseDouble(results.get(STATIONARY_ENTROPY)),
+         PRECISION
+      );
+      assertEquals(
+         "Unexpected transition entropy.",
+         EXPECTED_TRANSITION, Double.parseDouble(results.get(TRANSITION_ENTROPY)),
+         PRECISION
+      );
+   }
+
+   @Test
+   public void testGazeEntropyAnalyze_threeAoi() {
+      final double EXPECTED_STATIONARY = 0.4699915470362;
+      final double EXPECTED_TRANSITION = 0.282583442123752;
       DataEntry data = new DataEntry(Arrays.asList("AOI")) {{
          process(Arrays.asList("A"));
          process(Arrays.asList("B"));
@@ -24,6 +47,34 @@ public class GazeEntropyTest {
          process(Arrays.asList("A"));
          process(Arrays.asList("A"));
          process(Arrays.asList("B"));
+         process(Arrays.asList("C"));
+         process(Arrays.asList("C"));
+      }};
+      var results = GazeEntropy.analyze(data);
+      assertEquals(
+         "Unexpected stationary entropy.",
+         EXPECTED_STATIONARY,
+         Double.parseDouble(results.get(STATIONARY_ENTROPY)),
+         PRECISION
+      );
+      assertEquals(
+         "Unexpected transition entropy.",
+         EXPECTED_TRANSITION, Double.parseDouble(results.get(TRANSITION_ENTROPY)),
+         PRECISION
+      );
+   }
+
+   @Test
+   public void testGazeEntropyAnalyze_undefinedAoi() {
+      final double EXPECTED_STATIONARY = 0.301029995663981;
+      final double EXPECTED_TRANSITION = 0.288732293303828;
+      DataEntry data = new DataEntry(Arrays.asList("AOI")) {{
+         process(Arrays.asList("A"));
+         process(Arrays.asList(""));
+         process(Arrays.asList(""));
+         process(Arrays.asList("A"));
+         process(Arrays.asList("A"));
+         process(Arrays.asList(""));
       }};
       var results = GazeEntropy.analyze(data);
       assertEquals(

--- a/src/test/java/com/github/thed2lab/analysis/GazeEntropyTest.java
+++ b/src/test/java/com/github/thed2lab/analysis/GazeEntropyTest.java
@@ -1,0 +1,41 @@
+package com.github.thed2lab.analysis;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+
+public class GazeEntropyTest {
+
+   private final double PRECISION = 0.000000001; // allowable floating point error
+   private final String STATIONARY_ENTROPY = "stationary_entropy";
+   private final String TRANSITION_ENTROPY = "transition_entropy";
+
+   
+   @Test
+   public void testAnalyze_twoAoi() {
+      final double EXPECTED_STATIONARY = 0.301029995663981;
+      final double EXPECTED_TRANSITION = 0.288732293303828;
+      DataEntry data = new DataEntry(Arrays.asList("AOI")) {{
+         process(Arrays.asList("A"));
+         process(Arrays.asList("B"));
+         process(Arrays.asList("B"));
+         process(Arrays.asList("A"));
+         process(Arrays.asList("A"));
+         process(Arrays.asList("B"));
+      }};
+      var results = GazeEntropy.analyze(data);
+      assertEquals(
+         "Unexpected stationary entropy.",
+         EXPECTED_STATIONARY,
+         Double.parseDouble(results.get(STATIONARY_ENTROPY)),
+         PRECISION
+      );
+      assertEquals(
+         "Unexpected transition entropy.",
+         EXPECTED_TRANSITION, Double.parseDouble(results.get(TRANSITION_ENTROPY)),
+         PRECISION
+      );
+   }
+}


### PR DESCRIPTION
fixes #51 and fixes #52

- Rows that are not assigned explicitly to an AOI are treated as belonging to a single "Undefined Area" AOI in the entropy calcs
- The "No AOI" label was changed to "Undefined Area" because now it is being treated as first-class AOI, i.e., it is considered an AOI in all calculations relating to AOIs
- I fixed a filtering bug I introduced in PR #53
- Moved header string constants and screen size to a package-private final class with static fields, called constants. This class cannot be instantiated and only acts as a place to share constants between other classes in the package rather than have each class re-declare its own copy over and over again. This will help if gazepoint ever changes their output format/headers; we only need to change the strings in one place.