### PR TITLE
Fix single fixation bug and entropy NaN handling

### DIFF
--- a/src/main/java/com/github/thed2lab/analysis/DataFilter.java
+++ b/src/main/java/com/github/thed2lab/analysis/DataFilter.java
@@ -35,9 +35,11 @@ public class DataFilter {
                 lastValidFixation = data.getRow(row);
             }
         }
-        // Edge case: check last valid fixation is the last line of file or followed by only saccades
-        if (filtered.rowCount() != 0 && lastValidFixation != filtered.getRow(filtered.rowCount()-1)) {
-            filtered.process(lastValidFixation);    // add fixation if it wasn't already added
+        // Edge case: save last fixation if it exists and wasn't already added
+        if (lastValidFixation != null) {
+            if (filtered.rowCount() == 0 || !lastValidFixation.equals(filtered.getRow(filtered.rowCount()-1))) {
+                filtered.process(lastValidFixation);
+            }
         }
         
         return filtered;

--- a/src/main/java/com/github/thed2lab/analysis/GazeEntropy.java
+++ b/src/main/java/com/github/thed2lab/analysis/GazeEntropy.java
@@ -65,16 +65,18 @@ public class GazeEntropy {
 
         var results = new LinkedHashMap<String,String>();
 
-        results.put(
-            "stationary_entropy", //Output Header
-            String.valueOf(getStationaryEntropy(aoiProbability)) //Output Value
-            );
+        // Return NaN if no fixations/AOIs exist, otherwise calculate entropy
+        double stationaryEntropyValue = aoiProbability.isEmpty()
+            ? Double.NaN
+            : getStationaryEntropy(aoiProbability);
 
-        results.put(
-            "transition_entropy", //Output Header
-            String.valueOf(getTransitionEntropy(aoiProbability, transitionProbability)) //Output Value
-            );
-    
+        double transitionEntropyValue = transitionProbability.isEmpty()
+            ? Double.NaN
+            : getTransitionEntropy(aoiProbability, transitionProbability);
+
+        results.put("stationary_entropy", String.valueOf(stationaryEntropyValue));
+        results.put("transition_entropy", String.valueOf(transitionEntropyValue));
+
         return results;
     }
 


### PR DESCRIPTION
# Bug Fixes: Fixation Filtering & Entropy NaN Handling

## Fix 1: Single Fixation Not Saved

**File:** `DataFilter.java`
**Problem:** When a dataset has only one fixation, zero fixations were saved.
**Cause:** Edge case check required `filtered.rowCount() != 0`, which fails for single fixation.
**Solution:** Check `lastValidFixation != null` instead.

Before (1 fixation):

- Row 1: fixation 1 → nothing saved
- End of file → check fails (rowCount == 0)

After (1 fixation):

- Row 1: fixation 1 → nothing saved
- End of file → lastValidFixation exists, save it

---

## Fix 2: Entropy Returns NaN Instead of 0
**File:** `GazeEntropy.java`
**Problem:** `stationary_entropy` and `transition_entropy` returned `0.0` when data was empty or invalid.
**Solution:** Return `NaN` when:
  - `aoiProbability` is empty (no fixations)
  - `transitionProbability` is empty (no transitions)

Before (empty data):

- stationary_entropy: 0.0

After (empty data):

- stationary_entropy: NaN
- transition_entropy: NaN