### PR TITLE
Baseline Folder Fix

### DIFF
--- a/src/main/java/com/github/thed2lab/analysis/Windows.java
+++ b/src/main/java/com/github/thed2lab/analysis/Windows.java
@@ -43,9 +43,6 @@ public class Windows {
     public static void generateWindows(DataEntry allGaze, String outputDirectory, WindowSettings settings) {
         double time0 = Double.valueOf(allGaze.getValue(TIMESTAMP, 0));
 
-        // Generate baseline file
-        DataEntry baselineData = generateBaselineFiles(allGaze, outputDirectory + "/baseline", settings.eventBaselineDuration);
-
         // Tumbling Window
         if (settings.tumblingEnabled) {
             List<DataEntry> windows = spliceTumblingWindow(allGaze, settings.tumblingWindowSize);
@@ -64,10 +61,11 @@ public class Windows {
             outputWindowFiles(windows, time0, outputDirectory + "/hopping");
         }
 
-        // Event Window
+        // Event Window (baseline only needed for event-based windowing)
         if (settings.eventEnabled) {
+            DataEntry baselineData = generateBaselineFiles(allGaze, outputDirectory + "/baseline", settings.eventBaselineDuration);
             double baselineValue = getEventBaselineValue(baselineData, settings.event);
-            List<DataEntry> windows  = spliceEventWindow(allGaze, settings, baselineValue);
+            List<DataEntry> windows = spliceEventWindow(allGaze, settings, baselineValue);
             outputWindowFiles(windows, time0, outputDirectory + "/event");
         }
     }


### PR DESCRIPTION
# Baseline Folder Fix
Only generate baseline folder when event-based windowing is enabled

 ## Summary
 - Moved baseline folder generation inside the `eventEnabled` check in `Windows.generateWindows()`
 - Previously, a `baseline/` folder was created for every window type (tumbling, expanding, hopping), even though only
 event-based windowing uses baseline data

 ## Change
 **File:** `src/main/java/com/github/thed2lab/analysis/Windows.java`

 The `generateBaselineFiles()` call was unconditional. It is now scoped to the `if (settings.eventEnabled)` block, so
 the `baseline/` folder and its contents (`baseline.csv`, `baseline_DGMs.csv`) are only generated when event-based
 windowing is selected.

 ## Testing
 - All 95 existing tests pass
 - No tests depended on baseline generation for non-event window types
