### PR TITLE
Source per-AOI relative-angle triplets from whole-screen fixations

### DIFF
--- a/src/main/java/com/github/thed2lab/analysis/Analysis.java
+++ b/src/main/java/com/github/thed2lab/analysis/Analysis.java
@@ -252,15 +252,16 @@ public class Analysis {
     private static List<List<String>> generateResultsHelper(DataEntry allGaze, DataEntry areaGaze, DataEntry areaFixations) {
         // an argument could be made to filter before entering this function; there is a code smell due to blink rate and saccadeV changing
 
-        DataEntry validAllGaze = DataFilter.applyScreenSize(DataFilter.filterByValidity(allGaze), SCREEN_WIDTH, SCREEN_HEIGHT); 
+        DataEntry validAllGaze = DataFilter.applyScreenSize(DataFilter.filterByValidity(allGaze), SCREEN_WIDTH, SCREEN_HEIGHT);
+        DataEntry validAllFixations = DataFilter.applyScreenSize(DataFilter.filterByValidity(DataFilter.filterByFixations(allGaze)), SCREEN_WIDTH, SCREEN_HEIGHT);
         DataEntry validAreaGaze = DataFilter.applyScreenSize(DataFilter.filterByValidity(areaGaze), SCREEN_WIDTH, SCREEN_HEIGHT);
         DataEntry validAreaFixations = DataFilter.applyScreenSize(DataFilter.filterByValidity(areaFixations), SCREEN_WIDTH, SCREEN_HEIGHT);
-        
+
         LinkedHashMap<String,String> resultsMap = new LinkedHashMap<String, String>();
         resultsMap.putAll(Fixations.analyze(validAreaFixations));
         resultsMap.putAll(Saccades.analyze(validAreaFixations));
         resultsMap.putAll(SaccadeVelocity.analyze(validAllGaze, validAreaFixations));
-        resultsMap.putAll(Angles.analyze(validAreaFixations));
+        resultsMap.putAll(Angles.analyze(validAreaFixations, validAllFixations));
         resultsMap.putAll(ConvexHull.analyze(validAreaFixations));
         resultsMap.putAll(GazeEntropy.analyze(validAreaFixations));
         resultsMap.putAll(Blinks.analyze(areaGaze));    // unfiltered

--- a/src/main/java/com/github/thed2lab/analysis/Angles.java
+++ b/src/main/java/com/github/thed2lab/analysis/Angles.java
@@ -8,25 +8,33 @@ import static com.github.thed2lab.analysis.Constants.FIXATION_X;
 import static com.github.thed2lab.analysis.Constants.FIXATION_Y;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.Set;
 
 public class Angles {
-	
-	static public LinkedHashMap<String,String> analyze(DataEntry data) {
-		LinkedHashMap<String,String> results = new LinkedHashMap<String,String>();
-		ArrayList<Coordinate> allCoordinates = new ArrayList<>();
 
-		for (int row = 0; row < data.rowCount(); row++) {
-			Coordinate eachCoordinate = new Coordinate(
-				Double.valueOf(data.getValue(FIXATION_X, row)),
-				Double.valueOf(data.getValue(FIXATION_Y, row)),
-				Integer.valueOf(data.getValue(FIXATION_ID, row))
-			);
-			allCoordinates.add(eachCoordinate);
-		}
+	static public LinkedHashMap<String,String> analyze(DataEntry data) {
+		return analyze(data, null);
+	}
+
+	/**
+	 * Computes absolute and relative angle DGMs for an area (whole screen or AOI).
+	 * @param data fixations confined to the target area; absolute angles are computed
+	 * from this list and relative-angle triplets are credited to this area when their
+	 * middle fixation's id appears here.
+	 * @param allScreenData whole-screen fixations used to source consecutive A->B->C
+	 * triplets for the relative-angle metric. If {@code null} (legacy callers) the
+	 * triplet hunt falls back to {@code data} itself, preserving prior behavior.
+	 */
+	static public LinkedHashMap<String,String> analyze(DataEntry data, DataEntry allScreenData) {
+		LinkedHashMap<String,String> results = new LinkedHashMap<String,String>();
+		ArrayList<Coordinate> allCoordinates = toCoordinates(data);
 
 		ArrayList<Double> allAbsoluteDegrees = getAllAbsoluteAngles(allCoordinates);
-		ArrayList<Double> allRelativeDegrees = getAllRelativeAngles(allCoordinates);
+		ArrayList<Double> allRelativeDegrees = (allScreenData == null)
+			? getAllRelativeAngles(allCoordinates)
+			: getAllRelativeAngles(allCoordinates, toCoordinates(allScreenData));
 		//Absolute Degrees
 		results.put(
 			"sum_of_all_absolute_degrees", //Output Header
@@ -136,6 +144,48 @@ public class Angles {
 		}
 
 		return allAbsoluteDegrees;
+	}
+
+	private static ArrayList<Coordinate> toCoordinates(DataEntry data) {
+		ArrayList<Coordinate> coords = new ArrayList<>();
+		for (int row = 0; row < data.rowCount(); row++) {
+			coords.add(new Coordinate(
+				Double.valueOf(data.getValue(FIXATION_X, row)),
+				Double.valueOf(data.getValue(FIXATION_Y, row)),
+				Integer.valueOf(data.getValue(FIXATION_ID, row))
+			));
+		}
+		return coords;
+	}
+
+	// Whole-screen-aware overload. Hunts A->B->C triplets in the whole-screen
+	// fixation list (where consecutive ids are common) and credits a triplet to
+	// this area whenever B's fid is present in the area's fixation list. Per-AOI
+	// fixation ids are rarely consecutive, so the in-area-only triplet hunt
+	// collapses sparse AOIs to (sum=0, mean=NaN). Sourcing triplets from the
+	// whole screen makes the metric "turn angle at this AOI" rather than "turn
+	// angle while staying inside this AOI".
+	public static ArrayList<Double> getAllRelativeAngles(
+		ArrayList<Coordinate> areaCoordinates,
+		ArrayList<Coordinate> allScreenCoordinates
+	) {
+		Set<Integer> areaFids = new HashSet<>();
+		for (Coordinate c : areaCoordinates) areaFids.add(c.fid);
+
+		ArrayList<Double> allRelativeDegrees = new ArrayList<>();
+		for (int i = 1; i < allScreenCoordinates.size() - 1; i++) {
+			Coordinate a = allScreenCoordinates.get(i - 1);
+			Coordinate b = allScreenCoordinates.get(i);
+			Coordinate c = allScreenCoordinates.get(i + 1);
+			if (a.fid + 1 != b.fid || b.fid + 1 != c.fid) continue;
+			if (!areaFids.contains(b.fid)) continue;
+			ArrayList<Coordinate> triplet = new ArrayList<>(3);
+			triplet.add(a);
+			triplet.add(b);
+			triplet.add(c);
+			allRelativeDegrees.addAll(getAllRelativeAngles(triplet));
+		}
+		return allRelativeDegrees;
 	}
 
 	//given three points A, B and C with (X1, Y1) (X2, Y2) and (X3, Y3) respectively


### PR DESCRIPTION
## Summary
- Stops the per-AOI relative-angle metric from collapsing to `(sum=0, mean=NaN, ...)` on sparse AOIs.
- `Angles.getAllRelativeAngles` now accepts both the per-AOI and the whole-screen fixation lists; A->B->C triplets are hunted in the whole-screen list (where consecutive fids are common) and credited to an AOI when the middle fixation B's fid is also in that AOI.
- `Analysis.generateResultsHelper` builds `validAllFixations` and threads it to `Angles.analyze`, mirroring the existing `SaccadeVelocity` plumbing.
- Legacy single-arg `Angles.analyze` / `getAllRelativeAngles` overloads remain — whole-screen and per-window callers fall back to the in-area-only triplet hunt unchanged.
- Absolute angles untouched (pair-based; no bug).

This is a definitional change: the metric now reports "turn angle at this AOI" rather than "turn angle while staying inside this AOI". Matches the parallel TIDE-Gaze fix on `TheD2Lab/TIDE-Gaze` PR #31.

**Do not merge without Dr. Fu's sign-off.**

## Test plan
- [x] `mvn -B clean test` — `AnglesTest` and all other unrelated tests pass (the pre-existing `DataEntryTest.testWriteToCSV` failure is unaffected by this change).
- [x] Pilot run on `data/p10_all_gaze.csv` and `data/p20_all_gaze.csv`: every AOI populates `sum_of_all_relative_degrees` and `mean_relative_degree` with real values; means in the 53°–132° range across AOIs (e.g. p20 `RPM` with 54 fixations: mean=116.2°; p20 `ASI` with 99 fixations: mean=131.5°). No `NaN` cells anywhere.
- [x] Spot-check against TIDE-Gaze numbers on the shared pilot before merge.